### PR TITLE
Provide graceful shutdown capability; optionally hide Start at Login menu item

### DIFF
--- a/cmd/slowquit/Makefile
+++ b/cmd/slowquit/Makefile
@@ -1,0 +1,3 @@
+APP=SlowQuit
+
+include ../../menuet.mk

--- a/cmd/slowquit/SlowQuit.app/Contents/Info.plist
+++ b/cmd/slowquit/SlowQuit.app/Contents/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleExecutable</key>
+  <string>slowquit</string>
+  <key>CFBundleIconFile</key>
+  <string>icon</string>
+  <key>CFBundleGetInfoString</key>
+  <string>SlowQuit</string>
+  <key>CFBundleIdentifier</key>
+  <string>slowquit.menuet.caseymrm.github.com</string>
+  <key>CFBundleName</key>
+  <string>SlowQuit</string>
+  <key>CFBundleShortVersionString</key>
+  <string>0.1</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>IFMajorVersion</key>
+  <integer>0</integer>
+  <key>IFMinorVersion</key>
+  <integer>1</integer>
+  <key>NSHighResolutionCapable</key><true/>
+  <key>NSSupportsAutomaticGraphicsSwitching</key><true/>
+</dict>
+</plist>

--- a/cmd/slowquit/slowquit.go
+++ b/cmd/slowquit/slowquit.go
@@ -1,0 +1,52 @@
+// SlowQuit is an example application that demonstrates how to use the
+// graceful shutdown handles of a menuet app.
+package main
+
+import (
+	"log"
+	"time"
+
+	"github.com/caseymrm/menuet"
+)
+
+func main() {
+
+	// Configure the application
+	menuet.App().Label = "com.github.caseymrm.menuet.slowquit"
+	menuet.App().HideStartup()
+	menuet.App().SetMenuState(&menuet.MenuState{
+		Title: "SlowQuit",
+	})
+
+	// Hook up the graceful shutdown handles
+	wg, ctx := menuet.App().GracefulShutdownHandles()
+
+	// Start our long running routines (e.g an application or http server)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		t := time.NewTicker(time.Second)
+		defer t.Stop()
+		for {
+			select {
+			case <-t.C:
+				log.Println("caught a tick!")
+			case <-ctx.Done():
+				return
+			}
+
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-ctx.Done()
+		log.Println("caught shutdown signal")
+		time.Sleep(3 * time.Second)
+		log.Println("bye")
+	}()
+
+	// Run the app (does not return)
+	menuet.App().RunApplication()
+}

--- a/menuet.go
+++ b/menuet.go
@@ -41,6 +41,7 @@ type Application struct {
 	alertChannel          chan AlertClicked
 	currentState          *MenuState
 	nextState             *MenuState
+	hideStartupItem       bool
 	pendingStateChange    bool
 	debounceMutex         sync.Mutex
 	visibleMenuItemsMutex sync.RWMutex
@@ -79,6 +80,11 @@ func (a *Application) SetMenuState(state *MenuState) {
 // MenuChanged refreshes any open menus
 func (a *Application) MenuChanged() {
 	C.menuChanged()
+}
+
+// HideStartup prevents the Start at Login menu item from being displayed
+func (a *Application) HideStartup() {
+	a.hideStartupItem = true
 }
 
 // MenuState represents the title and drop down,
@@ -157,6 +163,11 @@ func menuClosed(uniqueCString *C.char) {
 //export notificationRespond
 func notificationRespond(id *C.char, response *C.char) {
 	App().NotificationResponder(C.GoString(id), C.GoString(response))
+}
+
+//export hideStartup
+func hideStartup() bool {
+	return App().hideStartupItem
 }
 
 //export runningAtStartup

--- a/menuet.m
+++ b/menuet.m
@@ -7,6 +7,7 @@ void itemClicked(const char *);
 void notificationRespond(const char *, const char *);
 const char *children(const char *);
 void menuClosed(const char *);
+bool hideStartup();
 bool runningAtStartup();
 void toggleStartup();
 
@@ -134,20 +135,29 @@ NSStatusItem *_statusItem;
 		items = [items arrayByAddingObjectsFromArray:@[
 				 @{@"Type" : @"separator",
 				   @"Clickable" : @YES},
-				 @{@"Text" : @"Start at Login",
-				   @"Clickable" : @YES},
+		]];
+		if (!hideStartup()) {
+			items = [items arrayByAddingObjectsFromArray:@[
+					@{@"Text" : @"Start at Login",
+					@"Clickable" : @YES},
+			]];
+		}
+		items = [items arrayByAddingObjectsFromArray:@[
 				 @{@"Text" : @"Quit",
 				   @"Clickable" : @YES},
 		]];
 	}
 	[self populate:items];
 	if (self.root) {
-		NSMenuItem *item = [self itemAtIndex:items.count - 2];
-		item.action = @selector(toggleStartup:);
-		if (runningAtStartup()) {
-			item.state = NSControlStateValueOn;
-		} else {
-			item.state = NSControlStateValueOff;
+		NSMenuItem *item = nil;
+		if (!hideStartup()) {
+			item = [self itemAtIndex:items.count - 2];
+			item.action = @selector(toggleStartup:);
+			if (runningAtStartup()) {
+				item.state = NSControlStateValueOn;
+			} else {
+				item.state = NSControlStateValueOff;
+			}
 		}
 		item = [self itemAtIndex:items.count - 1];
 		item.target = nil;

--- a/menuet.m
+++ b/menuet.m
@@ -10,6 +10,7 @@ void menuClosed(const char *);
 bool hideStartup();
 bool runningAtStartup();
 void toggleStartup();
+void shutdownWait();
 
 NSStatusItem *_statusItem;
 
@@ -160,8 +161,7 @@ NSStatusItem *_statusItem;
 			}
 		}
 		item = [self itemAtIndex:items.count - 1];
-		item.target = nil;
-		item.action = @selector(terminate:);
+		item.action = @selector(prepareShutdown:);
 	}
 	self.open = YES;
 }
@@ -178,6 +178,11 @@ NSStatusItem *_statusItem;
 
 - (void)toggleStartup:(id)sender {
 	toggleStartup();
+}
+
+- (void)prepareShutdown:(id)sender {
+	shutdownWait();
+	[NSApp terminate: nil];
 }
 
 @end


### PR DESCRIPTION
For a private project I'm working on, I am running a background server along with the menu app.

- We sometimes need to start the application as root, which makes the `Start at Login` not work as expected - so allow it to be hidden.
- We want to gracefully shutdown the background service when the menu bar app quits - so provide optional hooks into the terminate flow.