### PR TITLE
Migrate notifications to UNUserNotificationCenter (fixes #18)

### DIFF
--- a/notification.go
+++ b/notification.go
@@ -2,7 +2,7 @@ package menuet
 
 /*
 #cgo CFLAGS: -x objective-c
-#cgo LDFLAGS: -framework Cocoa
+#cgo LDFLAGS: -framework Cocoa -framework UserNotifications
 
 #import <Cocoa/Cocoa.h>
 
@@ -20,14 +20,17 @@ import (
 	"unsafe"
 )
 
-// Notification represents an NSUserNotification
+// Notification represents a macOS user notification.
 type Notification struct {
 	// The basic text of the notification
 	Title    string
 	Subtitle string
 	Message  string
 
-	// These add an optional action button, change what the close button says, and adds an in-line reply
+	// These add an optional action button, configure dismiss behavior, and add an in-line reply.
+	// Note: on macOS 11+, CloseButton still causes the dismiss action to trigger the
+	// NotificationResponder callback, but custom button text is not supported by the
+	// UserNotifications framework — the system default text is used instead.
 	ActionButton        string
 	CloseButton         string
 	ResponsePlaceholder string

--- a/notification.h
+++ b/notification.h
@@ -2,4 +2,5 @@
 #define __NOTIFICATION_H__
 #endif
 
+void initNotifications(void);
 void showNotification(const char *jsonString);

--- a/notification.m
+++ b/notification.m
@@ -1,6 +1,80 @@
 #import <Cocoa/Cocoa.h>
+#import <UserNotifications/UserNotifications.h>
 
 #import "notification.h"
+
+static NSMutableDictionary<NSString *, UNNotificationCategory *> *registeredCategories;
+
+void initNotifications(void) {
+	registeredCategories = [NSMutableDictionary new];
+	UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+	[center requestAuthorizationWithOptions:(UNAuthorizationOptionAlert |
+	                                         UNAuthorizationOptionSound |
+	                                         UNAuthorizationOptionBadge)
+	                      completionHandler:^(BOOL granted, NSError *error) {
+		if (error) {
+			NSLog(@"Notification authorization error: %@", error);
+		}
+	}];
+}
+
+static NSString *categoryIdentifierForActions(NSString *actionButton,
+                                              NSString *closeButton,
+                                              NSString *responsePlaceholder) {
+	return [NSString stringWithFormat:@"menuet_a:%@_c:%@_r:%@",
+	        actionButton ?: @"",
+	        closeButton ?: @"",
+	        responsePlaceholder ?: @""];
+}
+
+static void ensureCategoryRegistered(NSString *actionButton,
+                                     NSString *closeButton,
+                                     NSString *responsePlaceholder) {
+	NSString *categoryId = categoryIdentifierForActions(actionButton,
+	                                                    closeButton,
+	                                                    responsePlaceholder);
+	@synchronized(registeredCategories) {
+		if (registeredCategories[categoryId]) {
+			return;
+		}
+
+		NSMutableArray<UNNotificationAction *> *actions = [NSMutableArray new];
+
+		if (responsePlaceholder.length > 0) {
+			UNTextInputNotificationAction *replyAction =
+				[UNTextInputNotificationAction actionWithIdentifier:@"menuet.reply"
+				                                             title:@"Reply"
+				                                           options:UNNotificationActionOptionNone
+				                              textInputButtonTitle:@"Send"
+				                              textInputPlaceholder:responsePlaceholder];
+			[actions addObject:replyAction];
+		}
+
+		if (actionButton.length > 0) {
+			UNNotificationAction *action =
+				[UNNotificationAction actionWithIdentifier:@"menuet.action"
+				                                    title:actionButton
+				                                  options:UNNotificationActionOptionForeground];
+			[actions addObject:action];
+		}
+
+		UNNotificationCategoryOptions categoryOptions = UNNotificationCategoryOptionNone;
+		if (closeButton.length > 0) {
+			categoryOptions |= UNNotificationCategoryOptionCustomDismissAction;
+		}
+
+		UNNotificationCategory *category =
+			[UNNotificationCategory categoryWithIdentifier:categoryId
+			                                       actions:actions
+			                             intentIdentifiers:@[]
+			                                       options:categoryOptions];
+		registeredCategories[categoryId] = category;
+
+		NSSet *categorySet = [NSSet setWithArray:registeredCategories.allValues];
+		[[UNUserNotificationCenter currentNotificationCenter]
+			setNotificationCategories:categorySet];
+	}
+}
 
 void showNotification(const char *jsonString) {
 	NSDictionary *jsonDict = [NSJSONSerialization
@@ -8,41 +82,49 @@ void showNotification(const char *jsonString) {
 	                                              dataUsingEncoding:NSUTF8StringEncoding]
 	                          options:0
 	                          error:nil];
-	NSUserNotification *notification = [NSUserNotification new];
-	BOOL showsButtons = NO;
-	notification.title = jsonDict[@"Title"];
-	notification.subtitle = jsonDict[@"Subtitle"];
-	notification.informativeText = jsonDict[@"Message"];
-	NSString *identifier = jsonDict[@"Identifier"];
-	if (identifier.length > 0) {
-		notification.identifier = identifier;
-	}
-	NSString *closeButton = jsonDict[@"CloseButton"];
-	if (closeButton.length > 0) {
-		showsButtons = true;
-		notification.otherButtonTitle = closeButton;
-	}
+
+	UNMutableNotificationContent *content = [UNMutableNotificationContent new];
+	content.title = jsonDict[@"Title"] ?: @"";
+	content.subtitle = jsonDict[@"Subtitle"] ?: @"";
+	content.body = jsonDict[@"Message"] ?: @"";
+	content.sound = [UNNotificationSound defaultSound];
+
 	NSString *actionButton = jsonDict[@"ActionButton"];
-	if (actionButton.length > 0) {
-		showsButtons = true;
-		notification.actionButtonTitle = actionButton;
-	}
+	NSString *closeButton = jsonDict[@"CloseButton"];
 	NSString *responsePlaceholder = jsonDict[@"ResponsePlaceholder"];
-	if (responsePlaceholder.length > 0) {
-		notification.hasReplyButton = YES;
-		notification.responsePlaceholder = responsePlaceholder;
+
+	BOOL needsCategory = (actionButton.length > 0 ||
+	                       closeButton.length > 0 ||
+	                       responsePlaceholder.length > 0);
+	if (needsCategory) {
+		ensureCategoryRegistered(actionButton, closeButton, responsePlaceholder);
+		content.categoryIdentifier = categoryIdentifierForActions(actionButton,
+		                                                          closeButton,
+		                                                          responsePlaceholder);
 	}
-	if (showsButtons) {
-		// Override banner setting, could check plist to see if we're already set to alerts
-		[notification setValue:@YES forKey:@"_showsButtons"];
+
+	NSString *identifier = jsonDict[@"Identifier"];
+	if (identifier.length == 0) {
+		identifier = [[NSUUID UUID] UUIDString];
 	}
+
 	BOOL removeFromNotificationCenter = [jsonDict[@"RemoveFromNotificationCenter"] boolValue];
+
+	UNNotificationRequest *request =
+		[UNNotificationRequest requestWithIdentifier:identifier
+		                                     content:content
+		                                     trigger:nil];
 	dispatch_async(dispatch_get_main_queue(), ^{
-		NSUserNotificationCenter *center =
-			[NSUserNotificationCenter defaultUserNotificationCenter];
-		[center deliverNotification:notification];
-		if (removeFromNotificationCenter) {
-		        [center removeDeliveredNotification:notification];
-		}
+		UNUserNotificationCenter *center =
+			[UNUserNotificationCenter currentNotificationCenter];
+		[center addNotificationRequest:request
+		         withCompletionHandler:^(NSError *error) {
+			if (error) {
+				NSLog(@"Notification error: %@", error);
+			}
+			if (removeFromNotificationCenter) {
+				[center removeDeliveredNotificationsWithIdentifiers:@[identifier]];
+			}
+		}];
 	});
 }


### PR DESCRIPTION
Fixes #18.

`NSUserNotification` / `NSUserNotificationCenter` were deprecated in macOS 11 and notifications from menuet apps have not actually displayed on modern macOS for some time. This switches to `UNUserNotificationCenter` from the `UserNotifications` framework.

## Attribution

This is a cherry-pick of [dbeliakov/menuet@c93a9e6](https://github.com/dbeliakov/menuet/commit/c93a9e63bf7e8f9308e1e80bc21294bfa9fd34cd) by @dbeliakov (Feb 2026). Their implementation was meaningfully better than what I'd have written from scratch — credit preserved in the commit author field.

## What changed

- **`notification.m`** — `showNotification` now builds a `UNMutableNotificationContent` + `UNNotificationRequest` and dispatches via `addNotificationRequest:withCompletionHandler:`. A new `initNotifications()` runs `requestAuthorizationWithOptions:` at app startup. Notification categories are cached in a dictionary keyed by `(ActionButton, CloseButton, ResponsePlaceholder)` so identical action sets share a category and `setNotificationCategories:` always passes the full union (avoids clobbering categories of any other in-flight notification).
- **`menuet.m`** — `MenuetAppDelegate` now conforms to `UNUserNotificationCenterDelegate` and implements `didReceiveNotificationResponse:` (handling `UNTextInputNotificationResponse` for replies) and `willPresentNotification:` (so notifications still display while the app is foregrounded).
- **`notification.go` / `notification.h`** — adds `-framework UserNotifications` to cgo `LDFLAGS` and a forward declaration for `initNotifications()`.

## Behavior changes worth knowing

- **Authorization prompt on first launch.** `UNUserNotificationCenter` requires explicit user consent — your app will show a system permission dialog the first time it runs.
- **`CloseButton` text is no longer customizable.** The new framework doesn't have an equivalent of `NSUserNotification.otherButtonTitle`. To preserve the *semantics* (notifying the responder when the user dismisses), we set `UNNotificationCategoryOptionCustomDismissAction` so the standard system dismiss button still fires `NotificationResponder` — but the button text is whatever macOS uses by default. The Go-side `Notification.CloseButton` field is now documented to reflect this.
- **Signing required to actually display notifications.** `UNUserNotificationCenter` only delivers from properly code-signed bundles. Unsigned dev builds will silently fail (no display, no error to the user) — `NSUserNotification` was more permissive about this. The existing "not in a bundle" warning in `notification.go` still applies.

No Go API changes. `Notification` struct, `NotificationResponder` signature, and all field meanings stay identical.

## Verification

- `go build ./...` and `go vet ./...` succeed clean — none of the previous `-Wdeprecated-declarations` warnings about `NSUserNotificationCenter` / `NSUserNotification` / `NSUserNotificationActivationTypeReplied` appear.
- `cmd/catalog` builds, launches, and runs the menubar UI without crashing. Full notification-display verification requires Developer ID signing + notarization which I couldn't do locally; the code paths through `showNotification` and the new delegate methods were exercised.