### PR TITLE
v1.1.1 fixes: LaunchAgent Label, missing-Label crash, bundle docs (fixes #3, #7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,38 @@ menuet requires OS X.
 
 https://godoc.org/github.com/caseymrm/menuet
 
+## Running as a real macOS app
+
+`go run` is fine for early development, but several menuet features only work
+when the binary is launched from inside a proper macOS `.app` bundle. These
+requirements are enforced by macOS, not by menuet:
+
+* **Notifications** require a bundle. `UNUserNotificationCenter` will silently
+  no-op for a loose executable. The app also needs to be code-signed —
+  ad-hoc signing is not enough; you need a Developer ID signature (or full
+  notarization for distribution).
+* **Start at Login** writes a launchd plist that points at the executable
+  path. You'll typically want that path to be the binary inside your `.app`
+  bundle, not a `go run` temp directory.
+* **Auto-update** moves a new `.app` bundle on top of the running one, so it
+  obviously needs a bundle to update.
+
+The shared `menuet.mk` Makefile assembles a minimal bundle for you. From your
+app directory, create a `Makefile` like:
+
+```make
+APP=My App
+IDENTIFIER=com.example.myapp
+include $(GOPATH)/src/github.com/caseymrm/menuet/menuet.mk
+```
+
+Then `make run` builds the binary into `My App.app/Contents/MacOS/myapp`,
+generates `My App.app/Contents/Info.plist` with your `CFBundleIdentifier`,
+and launches it. The `cmd/catalog` example uses this pattern.
+
+To sign the bundle for notifications and distribution, set `IDENTITY` to a
+Developer ID Application certificate from your Keychain and run `make sign`.
+
 ## Apps built with Menuet
 
 * [Why Awake?](https://github.com/caseymrm/whyawake) - shows why your Mac can't sleep, and lets you force it awake

--- a/startup.go
+++ b/startup.go
@@ -86,7 +86,7 @@ var launchdString = `
  <!DOCTYPE plist PUBLIC \"-//Apple Computer//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\" >
  <plist version='1.0'>
    <dict>
-     <key>Label</key><string>{{.Name}}</string>
+     <key>Label</key><string>{{.Label}}</string>
      <key>Program</key><string>{{.Executable}}</string>
      <key>StandardOutPath</key><string>/tmp/{{.Label}}-out.log</string>
      <key>StandardErrorPath</key><string>/tmp/{{.Label}}-err.log</string>

--- a/startup.go
+++ b/startup.go
@@ -1,6 +1,7 @@
 package menuet
 
 import (
+	"bytes"
 	"log"
 	"os"
 	"os/user"
@@ -11,7 +12,8 @@ import (
 
 func (a *Application) getStartupPath() string {
 	if a.Label == "" {
-		log.Fatal("Need to set a Label for the app")
+		log.Println("Warning: no application Label set, cannot manage Start at Login")
+		return ""
 	}
 	u, err := user.Current()
 	if err != nil {
@@ -22,20 +24,20 @@ func (a *Application) getStartupPath() string {
 }
 
 func (a *Application) runningAtStartup() bool {
-	if a.Label == "" {
-		log.Println("Warning: no application Label set")
+	path := a.getStartupPath()
+	if path == "" {
 		return false
 	}
-	_, err := os.Stat(a.getStartupPath())
-	if err == nil {
-		return true
-	}
-	return false
+	_, err := os.Stat(path)
+	return err == nil
 }
 
 func (a *Application) removeStartupItem() {
-	err := os.Remove(a.getStartupPath())
-	if err != nil {
+	path := a.getStartupPath()
+	if path == "" {
+		return
+	}
+	if err := os.Remove(path); err != nil {
 		log.Printf("os.Remove: %v", err)
 	}
 }
@@ -43,11 +45,29 @@ func (a *Application) removeStartupItem() {
 var launchdOnce sync.Once
 var launchdTemplate *template.Template
 
+type launchdPlistData struct {
+	Name       string
+	Label      string
+	Executable string
+}
+
+func renderLaunchdPlist(data launchdPlistData) (string, error) {
+	launchdOnce.Do(func() {
+		launchdTemplate = template.Must(template.New("launchdConfig").Parse(launchdString))
+	})
+	var buf bytes.Buffer
+	if err := launchdTemplate.Execute(&buf, data); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
 func (a *Application) addStartupItem() {
 	path := a.getStartupPath()
-	// Make sure ~/Library/LaunchAgents exists
-	err := os.MkdirAll(filepath.Dir(path), 0700)
-	if err != nil {
+	if path == "" {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
 		log.Printf("os.MkdirAll: %v", err)
 		return
 	}
@@ -56,27 +76,17 @@ func (a *Application) addStartupItem() {
 		log.Printf("os.Executable: %v", err)
 		return
 	}
-	f, err := os.Create(path)
+	rendered, err := renderLaunchdPlist(launchdPlistData{
+		Name:       a.Name,
+		Label:      a.Label,
+		Executable: executable,
+	})
 	if err != nil {
-		log.Printf("os.Create: %v", err)
+		log.Printf("renderLaunchdPlist: %v", err)
 		return
 	}
-	defer f.Close()
-	launchdOnce.Do(func() {
-		launchdTemplate = template.Must(template.New("launchdConfig").Parse(launchdString))
-	})
-	err = launchdTemplate.Execute(f,
-		struct {
-			Name       string
-			Label      string
-			Executable string
-		}{
-			a.Name,
-			a.Label,
-			executable,
-		})
-	if err != nil {
-		log.Printf("template.Execute: %v", err)
+	if err := os.WriteFile(path, []byte(rendered), 0644); err != nil {
+		log.Printf("os.WriteFile: %v", err)
 		return
 	}
 }

--- a/startup_test.go
+++ b/startup_test.go
@@ -1,0 +1,89 @@
+package menuet
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderLaunchdPlistUsesLabelForLaunchdLabelKey(t *testing.T) {
+	// Regression for the bug where the plist template used {{.Name}} for the
+	// launchd <key>Label</key> value. Apps that left Name empty would emit a
+	// plist with an empty Label and launchd would silently ignore the agent.
+	rendered, err := renderLaunchdPlist(launchdPlistData{
+		Name:       "Human Readable Name",
+		Label:      "com.example.app",
+		Executable: "/Applications/App.app/Contents/MacOS/app",
+	})
+	if err != nil {
+		t.Fatalf("renderLaunchdPlist: %v", err)
+	}
+	if !strings.Contains(rendered, "<key>Label</key><string>com.example.app</string>") {
+		t.Errorf("launchd Label should be the reverse-DNS identifier; rendered:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "<string>Human Readable Name</string>") {
+		t.Errorf("Name field should not leak into the plist; rendered:\n%s", rendered)
+	}
+}
+
+func TestRenderLaunchdPlistWithEmptyNameStillProducesValidLabel(t *testing.T) {
+	// cmd/weather and many menuet consumers only set Label, never Name.
+	// Before the fix this case produced an empty <key>Label</key><string></string>.
+	rendered, err := renderLaunchdPlist(launchdPlistData{
+		Name:       "",
+		Label:      "com.example.app",
+		Executable: "/Applications/App.app/Contents/MacOS/app",
+	})
+	if err != nil {
+		t.Fatalf("renderLaunchdPlist: %v", err)
+	}
+	if !strings.Contains(rendered, "<key>Label</key><string>com.example.app</string>") {
+		t.Errorf("empty Name should not blank out the launchd Label; rendered:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "<string></string>") {
+		t.Errorf("plist should not contain an empty <string></string>; rendered:\n%s", rendered)
+	}
+}
+
+func TestRenderLaunchdPlistContainsExecutable(t *testing.T) {
+	exe := "/Applications/App.app/Contents/MacOS/app"
+	rendered, err := renderLaunchdPlist(launchdPlistData{
+		Label:      "com.example.app",
+		Executable: exe,
+	})
+	if err != nil {
+		t.Fatalf("renderLaunchdPlist: %v", err)
+	}
+	if !strings.Contains(rendered, "<key>Program</key><string>"+exe+"</string>") {
+		t.Errorf("plist should embed the executable path; rendered:\n%s", rendered)
+	}
+}
+
+func TestGetStartupPathWithoutLabelReturnsEmpty(t *testing.T) {
+	// Regression for issue #7: previously this called log.Fatal and crashed
+	// the host menubar app. The fix is to warn and return empty so callers
+	// can no-op.
+	a := &Application{}
+	if got := a.getStartupPath(); got != "" {
+		t.Errorf("getStartupPath() with no Label = %q, want empty string", got)
+	}
+}
+
+func TestRunningAtStartupWithoutLabelDoesNotPanic(t *testing.T) {
+	a := &Application{}
+	if a.runningAtStartup() {
+		t.Errorf("runningAtStartup() with no Label = true, want false")
+	}
+}
+
+func TestRemoveStartupItemWithoutLabelIsNoOp(t *testing.T) {
+	// Should not panic, should not attempt os.Remove("") which produces
+	// confusing "remove : no such file or directory" log lines.
+	a := &Application{}
+	a.removeStartupItem()
+}
+
+func TestAddStartupItemWithoutLabelIsNoOp(t *testing.T) {
+	// Previously this path crashed via log.Fatal in getStartupPath.
+	a := &Application{}
+	a.addStartupItem()
+}

--- a/update.go
+++ b/update.go
@@ -140,11 +140,18 @@ func appPath() (string, string) {
 	if err != nil {
 		log.Fatalf("os.Executable: %v", err)
 	}
-	d := strings.Split(currentPath, string(os.PathSeparator))
+	return currentPath, bundlePathForExecutable(currentPath)
+}
+
+// bundlePathForExecutable returns the .app bundle path containing the given
+// executable, or "" if the executable is not inside one. A bundle layout is
+// recognized when the executable lives at .../<Something>.app/Contents/MacOS/<binary>.
+func bundlePathForExecutable(execPath string) string {
+	d := strings.Split(execPath, string(os.PathSeparator))
 	if len(d) < 5 || d[len(d)-2] != "MacOS" || d[len(d)-3] != "Contents" {
-		return currentPath, ""
+		return ""
 	}
-	return currentPath, strings.Join(d[0:len(d)-3], string(os.PathSeparator))
+	return strings.Join(d[0:len(d)-3], string(os.PathSeparator))
 }
 
 func getReleasesFromGitHub(project string) ([]release, error) {

--- a/update_test.go
+++ b/update_test.go
@@ -2,27 +2,169 @@ package menuet
 
 import "testing"
 
-var testProject = "caseymrm/whyawake"
-var testOldVersion = "v0.3"
+func TestGetReleaseToUpdateTo(t *testing.T) {
+	r := func(tag string) release { return release{TagName: tag} }
+	releases := []release{r("v1.2.0"), r("v1.1.0"), r("v1.0.0")}
 
-func TestCheckForRelease(t *testing.T) {
-	checkForRestart()
-	release := checkForNewRelease(testProject, testOldVersion)
-	if release == nil {
-		t.Fail()
+	tests := []struct {
+		name           string
+		releases       []release
+		currentVersion string
+		wantTag        string // "" means nil result
+	}{
+		{
+			name:           "empty release list returns nil",
+			releases:       nil,
+			currentVersion: "v1.0.0",
+			wantTag:        "",
+		},
+		{
+			name:           "already on latest returns nil",
+			releases:       releases,
+			currentVersion: "v1.2.0",
+			wantTag:        "",
+		},
+		{
+			name:           "behind by one returns latest",
+			releases:       releases,
+			currentVersion: "v1.1.0",
+			wantTag:        "v1.2.0",
+		},
+		{
+			name:           "behind by two returns latest",
+			releases:       releases,
+			currentVersion: "v1.0.0",
+			wantTag:        "v1.2.0",
+		},
+		{
+			name:           "current version not in list returns nil (we don't downgrade strangers)",
+			releases:       releases,
+			currentVersion: "v0.9.0",
+			wantTag:        "",
+		},
 	}
-	if release.TagName != "v0.4" {
-		t.Errorf("Unexpected release: %+v", release)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getReleaseToUpdateTo(tt.releases, tt.currentVersion)
+			if tt.wantTag == "" {
+				if got != nil {
+					t.Errorf("got %+v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("got nil, want release with tag %q", tt.wantTag)
+			}
+			if got.TagName != tt.wantTag {
+				t.Errorf("got tag %q, want %q", got.TagName, tt.wantTag)
+			}
+		})
 	}
 }
 
-func TestUpdateInPlace(t *testing.T) {
-	checkForRestart()
-	release := checkForNewRelease(testProject, testOldVersion)
-	if release == nil {
-		t.Fail()
+func TestDownloadURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		assets   []struct{ name, url string }
+		wantName string
+		wantURL  string
+	}{
+		{
+			name:     "no assets returns empty",
+			assets:   nil,
+			wantName: "",
+			wantURL:  "",
+		},
+		{
+			name: "single zip asset is picked",
+			assets: []struct{ name, url string }{
+				{"App.zip", "https://example.com/App.zip"},
+			},
+			wantName: "App.zip",
+			wantURL:  "https://example.com/App.zip",
+		},
+		{
+			name: "first zip asset wins over later ones",
+			assets: []struct{ name, url string }{
+				{"App.zip", "https://example.com/App.zip"},
+				{"App-debug.zip", "https://example.com/App-debug.zip"},
+			},
+			wantName: "App.zip",
+			wantURL:  "https://example.com/App.zip",
+		},
+		{
+			name: "non-zip assets are skipped",
+			assets: []struct{ name, url string }{
+				{"README.md", "https://example.com/README.md"},
+				{"App.tar.gz", "https://example.com/App.tar.gz"},
+				{"App.zip", "https://example.com/App.zip"},
+			},
+			wantName: "App.zip",
+			wantURL:  "https://example.com/App.zip",
+		},
+		{
+			name: "only non-zip assets returns empty",
+			assets: []struct{ name, url string }{
+				{"App.dmg", "https://example.com/App.dmg"},
+			},
+			wantName: "",
+			wantURL:  "",
+		},
 	}
-	err := updateApp(release)
-	t.Errorf("UpdateApp: %+v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rel := &release{}
+			for _, a := range tt.assets {
+				rel.Assets = append(rel.Assets, struct {
+					Name        string `json:"name"`
+					DownloadURL string `json:"browser_download_url"`
+				}{Name: a.name, DownloadURL: a.url})
+			}
+			gotName, gotURL := downloadURL(rel)
+			if gotName != tt.wantName || gotURL != tt.wantURL {
+				t.Errorf("got (%q, %q), want (%q, %q)", gotName, gotURL, tt.wantName, tt.wantURL)
+			}
+		})
+	}
+}
 
+func TestBundlePathForExecutable(t *testing.T) {
+	tests := []struct {
+		name string
+		exec string
+		want string
+	}{
+		{
+			name: "executable inside a .app bundle",
+			exec: "/Applications/My App.app/Contents/MacOS/myapp",
+			want: "/Applications/My App.app",
+		},
+		{
+			name: "nested .app bundle",
+			exec: "/Users/casey/Projects/foo/Foo.app/Contents/MacOS/foo",
+			want: "/Users/casey/Projects/foo/Foo.app",
+		},
+		{
+			name: "loose executable returns empty",
+			exec: "/usr/local/bin/myapp",
+			want: "",
+		},
+		{
+			name: "executable in wrong subdirectory returns empty",
+			exec: "/Applications/My App.app/Contents/Resources/myapp",
+			want: "",
+		},
+		{
+			name: "executable missing the .app/Contents/MacOS layer returns empty",
+			exec: "/Applications/myapp",
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := bundlePathForExecutable(tt.exec); got != tt.want {
+				t.Errorf("bundlePathForExecutable(%q) = %q, want %q", tt.exec, got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Three small, independent bug/doc fixes plus a chunk of new unit-test coverage. All ship together as v1.1.1.

## 1. LaunchAgent plist used Name instead of Label

\`startup.go\`'s plist template wrote \`<key>Label</key><string>{{.Name}}</string>\`, but \`Name\` is the human-readable app name (often empty — \`cmd/weather\` only sets \`Label\`). The launchd \`Label\` key needs the reverse-DNS identifier (which lives in \`Application.Label\`). Result: \"Start at Login\" silently broke for any consumer that didn't also set \`Name\`.

Cherry-picked from [dbeliakov/menuet@d5ef22e](https://github.com/dbeliakov/menuet/commit/d5ef22e), authorship preserved.

## 2. Missing-Label crash (closes #7)

\`getStartupPath()\` called \`log.Fatal(\"Need to set a Label for the app\")\` when \`Application.Label\` was empty. That terminates the *entire menubar app* the moment a user clicks \"Start at Login\" without Label set. \`runningAtStartup()\` two functions later already did the right thing — warn and return. Now \`getStartupPath\` matches that pattern (warn once, return \`\"\"\`) and every caller (\`addStartupItem\`, \`removeStartupItem\`, \`runningAtStartup\`) no-ops on empty path.

## 3. Document bundle + signing requirement (closes #3)

Adds a \"Running as a real macOS app\" section to the README explaining which features (notifications, Start at Login, auto-update) require a bundle, points at \`menuet.mk\` for the scaffolding, and calls out the new signing requirement for notifications post-v1.1.0.

## 4. Unit-test coverage

The library was almost entirely untested. This PR adds 22 new tests covering the bug-fix areas plus the autoupdate decision logic, and removes the pre-existing broken \`update_test.go\` (one test hit the live GitHub API, the other had an unconditional \`t.Errorf\` that always failed).

  * \`renderLaunchdPlist\` — verifies the Label-key bug regression-tests cleanly. To prove the test catches the bug, I temporarily reverted the fix locally and the empty-Name case failed with the expected empty-\`<string></string>\` output.
  * \`getStartupPath\` / \`addStartupItem\` / \`removeStartupItem\` / \`runningAtStartup\` — all four are safe to call with no Label set.
  * \`getReleaseToUpdateTo\` — table-driven (empty list, on-latest, behind-by-one, behind-by-two, unknown current version).
  * \`downloadURL\` — table-driven (no assets, single zip, first-zip-wins, non-zip filtering).
  * \`bundlePathForExecutable\` — newly extracted from \`appPath\` so the path-parsing logic can be tested without touching \`os.Executable\`.

\`go test ./...\` runs in ~0.3s with no network calls.

## Out of scope

  * Issue #6 (release Makefile) — bigger lift, separate session.
  * Issue #9 (beta channel autoupdate) — next PR, will be v1.2.0.
  * \`appPath()\` still uses \`log.Fatal\` on \`os.Executable\` failure. Lower-impact than the startup.go case (only reachable from the auto-update path) so I left it alone for a tighter diff.