### PR TITLE
Allow opting into prerelease autoupdates (fixes #9)

### DIFF
--- a/menuet.go
+++ b/menuet.go
@@ -34,6 +34,11 @@ type Application struct {
 	AutoUpdate struct {
 		Version string
 		Repo    string // For example "caseymrm/menuet"
+		// AllowPrerelease opts in to GitHub releases marked as prereleases.
+		// When false (the default), prereleases are filtered out before
+		// choosing what to update to. Apps on a prerelease are not
+		// downgraded to the latest stable — switch channels manually.
+		AllowPrerelease bool
 	}
 
 	// NotificationResponder is a handler called when notification respond

--- a/update.go
+++ b/update.go
@@ -17,8 +17,9 @@ import (
 )
 
 type release struct {
-	TagName string `json:"tag_name"`
-	Assets  []struct {
+	TagName    string `json:"tag_name"`
+	Prerelease bool   `json:"prerelease"`
+	Assets     []struct {
 		Name        string `json:"name"`
 		DownloadURL string `json:"browser_download_url"`
 	} `json:"assets"`
@@ -28,7 +29,7 @@ func (a *Application) checkForUpdates() {
 	checkForRestart()
 	ticker := time.NewTicker(24 * time.Hour)
 	for ; true; <-ticker.C {
-		release := checkForNewRelease(a.AutoUpdate.Repo, a.AutoUpdate.Version)
+		release := checkForNewRelease(a.AutoUpdate.Repo, a.AutoUpdate.Version, a.AutoUpdate.AllowPrerelease)
 		if release == nil {
 			continue
 		}
@@ -62,7 +63,7 @@ func checkForRestart() {
 	syscall.Kill(ppid, syscall.SIGTERM)
 }
 
-func checkForNewRelease(githubProject, currentVersion string) *release {
+func checkForNewRelease(githubProject, currentVersion string, allowPrerelease bool) *release {
 	if currentVersion == "" {
 		log.Printf("Not checking updates for dev version")
 		return nil
@@ -72,7 +73,7 @@ func checkForNewRelease(githubProject, currentVersion string) *release {
 		log.Printf("Error fetching github releases: %v", err)
 		return nil
 	}
-	return getReleaseToUpdateTo(releases, currentVersion)
+	return getReleaseToUpdateTo(releases, currentVersion, allowPrerelease)
 }
 
 func updateApp(release *release) error {
@@ -244,7 +245,16 @@ func unzipBundle(filename string) (string, error) {
 	return bundle, nil
 }
 
-func getReleaseToUpdateTo(releases []release, currentVersion string) *release {
+func getReleaseToUpdateTo(releases []release, currentVersion string, allowPrerelease bool) *release {
+	if !allowPrerelease {
+		filtered := releases[:0:0]
+		for _, r := range releases {
+			if !r.Prerelease {
+				filtered = append(filtered, r)
+			}
+		}
+		releases = filtered
+	}
 	if len(releases) == 0 {
 		log.Printf("No github releases found")
 		return nil

--- a/update_test.go
+++ b/update_test.go
@@ -3,14 +3,21 @@ package menuet
 import "testing"
 
 func TestGetReleaseToUpdateTo(t *testing.T) {
-	r := func(tag string) release { return release{TagName: tag} }
-	releases := []release{r("v1.2.0"), r("v1.1.0"), r("v1.0.0")}
+	stable := func(tag string) release { return release{TagName: tag} }
+	pre := func(tag string) release { return release{TagName: tag, Prerelease: true} }
+	stables := []release{stable("v1.2.0"), stable("v1.1.0"), stable("v1.0.0")}
+	mixed := []release{
+		stable("v2.0.0"),
+		pre("v2.0.0-beta1"),
+		stable("v1.0.0"),
+	}
 
 	tests := []struct {
-		name           string
-		releases       []release
-		currentVersion string
-		wantTag        string // "" means nil result
+		name            string
+		releases        []release
+		currentVersion  string
+		allowPrerelease bool
+		wantTag         string // "" means nil result
 	}{
 		{
 			name:           "empty release list returns nil",
@@ -20,32 +27,69 @@ func TestGetReleaseToUpdateTo(t *testing.T) {
 		},
 		{
 			name:           "already on latest returns nil",
-			releases:       releases,
+			releases:       stables,
 			currentVersion: "v1.2.0",
 			wantTag:        "",
 		},
 		{
 			name:           "behind by one returns latest",
-			releases:       releases,
+			releases:       stables,
 			currentVersion: "v1.1.0",
 			wantTag:        "v1.2.0",
 		},
 		{
 			name:           "behind by two returns latest",
-			releases:       releases,
+			releases:       stables,
 			currentVersion: "v1.0.0",
 			wantTag:        "v1.2.0",
 		},
 		{
-			name:           "current version not in list returns nil (we don't downgrade strangers)",
-			releases:       releases,
+			name:           "current version not in list returns nil",
+			releases:       stables,
 			currentVersion: "v0.9.0",
 			wantTag:        "",
+		},
+
+		// Prerelease handling
+		{
+			name:            "stable channel skips prereleases when picking latest",
+			releases:        mixed,
+			currentVersion:  "v1.0.0",
+			allowPrerelease: false,
+			wantTag:         "v2.0.0",
+		},
+		{
+			name:            "stable channel skips prereleases even when only prereleases exist",
+			releases:        []release{pre("v1.0.0-beta1")},
+			currentVersion:  "v0.9.0",
+			allowPrerelease: false,
+			wantTag:         "",
+		},
+		{
+			name:            "user on a prerelease with stable channel does not downgrade",
+			releases:        mixed,
+			currentVersion:  "v2.0.0-beta1",
+			allowPrerelease: false,
+			wantTag:         "",
+		},
+		{
+			name:            "beta channel offers a newer prerelease over the current stable",
+			releases:        mixed,
+			currentVersion:  "v1.0.0",
+			allowPrerelease: true,
+			wantTag:         "v2.0.0",
+		},
+		{
+			name:            "beta channel updates a prerelease to the latest including prereleases",
+			releases:        []release{pre("v2.0.0-beta2"), pre("v2.0.0-beta1")},
+			currentVersion:  "v2.0.0-beta1",
+			allowPrerelease: true,
+			wantTag:         "v2.0.0-beta2",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := getReleaseToUpdateTo(tt.releases, tt.currentVersion)
+			got := getReleaseToUpdateTo(tt.releases, tt.currentVersion, tt.allowPrerelease)
 			if tt.wantTag == "" {
 				if got != nil {
 					t.Errorf("got %+v, want nil", got)


### PR DESCRIPTION
Closes #9.

Adds \`Application.AutoUpdate.AllowPrerelease bool\` so apps can opt in to GitHub releases marked as \`prerelease\`. Default is false — same behavior as today, just now we actually filter prereleases out explicitly instead of accidentally treating them as stable.

## Design

- \`getReleaseToUpdateTo\` takes a new \`allowPrerelease\` parameter. When false, prereleases are filtered out of the input slice before the existing \"latest is releases[0]\" decision runs.
- Apps on a prerelease with the stable channel set are *not* downgraded to the latest stable. The existing \"current version not in list, don't update\" guard handles this case naturally — flipping channels is a user action.
- Adds \`Prerelease bool\` to the internal \`release\` struct (deserializes from GitHub's existing \`prerelease\` field).

## Tests

Five new table-driven cases on top of the existing five:
- stable channel skips prereleases when picking latest
- stable channel returns nil when only prereleases exist
- user on a prerelease isn't downgraded by the stable channel
- beta channel offers a newer prerelease over current stable
- beta channel updates a prerelease to the latest including prereleases

Written before the implementation — they failed to compile against the old signature, drove the change, then passed.

## Out of scope

Issues #6 (release Makefile), #11, #16 (user questions Casey already engaged with). The two question-shaped issues are arguably closeable as resolved; I'll surface that separately rather than touch them in this PR.