### PR TITLE
Add customizable Start at Login and Quit menu item labels

### DIFF
--- a/menuet.go
+++ b/menuet.go
@@ -44,6 +44,11 @@ type Application struct {
 	// NotificationResponder is a handler called when notification respond
 	NotificationResponder func(id, response string)
 
+	// StartAtLoginLabel overrides the default "Start at Login" menu item text
+	StartAtLoginLabel string
+	// QuitLabel overrides the default "Quit" menu item text
+	QuitLabel string
+
 	alertChannel          chan AlertClicked
 	currentState          *MenuState
 	nextState             *MenuState
@@ -192,6 +197,24 @@ func notificationRespond(id *C.char, response *C.char) {
 //export hideStartup
 func hideStartup() bool {
 	return App().hideStartupItem
+}
+
+//export startAtLoginLabel
+func startAtLoginLabel() *C.char {
+	label := App().StartAtLoginLabel
+	if label == "" {
+		label = "Start at Login"
+	}
+	return C.CString(label)
+}
+
+//export quitLabel
+func quitLabel() *C.char {
+	label := App().QuitLabel
+	if label == "" {
+		label = "Quit"
+	}
+	return C.CString(label)
 }
 
 //export runningAtStartup

--- a/menuet.m
+++ b/menuet.m
@@ -9,6 +9,8 @@ void notificationRespond(const char *, const char *);
 const char *children(const char *);
 void menuClosed(const char *);
 bool hideStartup();
+char *startAtLoginLabel();
+char *quitLabel();
 bool runningAtStartup();
 void toggleStartup();
 void shutdownWait();

--- a/menuet.m
+++ b/menuet.m
@@ -140,15 +140,19 @@ NSStatusItem *_statusItem;
 				   @"Clickable" : @YES},
 		]];
 		if (!hideStartup()) {
+			char *startLabel = startAtLoginLabel();
 			items = [items arrayByAddingObjectsFromArray:@[
-					@{@"Text" : @"Start at Login",
+					@{@"Text" : [NSString stringWithUTF8String:startLabel],
 					@"Clickable" : @YES},
 			]];
+			free(startLabel);
 		}
+		char *qLabel = quitLabel();
 		items = [items arrayByAddingObjectsFromArray:@[
-				 @{@"Text" : @"Quit",
+				 @{@"Text" : [NSString stringWithUTF8String:qLabel],
 				   @"Clickable" : @YES},
 		]];
+		free(qLabel);
 	}
 	[self populate:items];
 	if (self.root) {


### PR DESCRIPTION
Cherry-pick of [dbeliakov/menuet@93c527d](https://github.com/dbeliakov/menuet/commit/93c527d) + [@264c4b6](https://github.com/dbeliakov/menuet/commit/264c4b6) (forward-decl follow-up). Both commits' authorship preserved.

## What it adds

Two new optional fields on \`Application\`:

\`\`\`go
type Application struct {
    // ...existing...
    StartAtLoginLabel string // overrides "Start at Login"
    QuitLabel         string // overrides "Quit"
}
\`\`\`

Empty (the default) gives the existing strings, so this is purely additive — no consumer needs to change anything. Useful for localization, branding, or alternate phrasings (\"Launch on Startup\", \"Exit\", etc.).

## Implementation

The Go fields are exposed to the Objective-C side via \`//export\` functions (\`startAtLoginLabel\` and \`quitLabel\`), which return \`*C.char\` via \`C.CString\`. The Objective-C side reads them when building the root menu, falling back to the hardcoded strings if empty, and properly \`free()\`s the C strings after use. The forward decls in the second cherry-pick are required for the cgo bridge to compile cleanly.

## Tests

No new tests. The cgo-exported helpers are 2-line wrappers (\`if label == "" { label = "default" }\`) and testing them through cgo would be ceremony around trivial fallback logic. The default-fallback behavior is small enough to read; if it ever grows past a one-liner it's worth extracting a pure helper at that point.

\`go build ./...\`, \`go vet ./...\`, \`go test ./...\` all clean.