### PR TITLE
BREAKING: Add secure password input fields to Alert (v2.0.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ func menuItems() []menuet.MenuItem {
 		Clicked: func() {
 			response := menuet.App().Alert(menuet.Alert{
 				MessageText: "Where would you like to display the weather for?",
-				Inputs:      []string{"Location"},
+				Inputs:      []menuet.AlertInput{{Placeholder: "Location"}},
 				Buttons:     []string{"Search", "Cancel"},
 			})
 			if response.Button == 0 && len(response.Inputs) == 1 && response.Inputs[0] != "" {

--- a/alert.go
+++ b/alert.go
@@ -20,12 +20,26 @@ import (
 	"unsafe"
 )
 
+// InputType specifies the type of input field in an alert
+type InputType int
+
+const (
+	InputText     InputType = iota // regular text field
+	InputPassword                  // masked password field (NSSecureTextField)
+)
+
+// AlertInput defines an input field in an alert
+type AlertInput struct {
+	Placeholder string
+	Type        InputType
+}
+
 // Alert represents an NSAlert
 type Alert struct {
 	MessageText     string
 	InformativeText string
 	Buttons         []string
-	Inputs          []string
+	Inputs          []AlertInput
 }
 
 // AlertClicked represents a selected alert button

--- a/alert.m
+++ b/alert.m
@@ -29,11 +29,17 @@ void showAlert(const char *jsonString) {
 		        BOOL first = false;
 		        int y = 30 * inputs.count;
 		        accessoryView = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, 200, y)];
-		        for (NSString *input in inputs) {
+		        for (NSDictionary *input in inputs) {
 		                y -= 30;
-		                EditableNSTextField *textfield =
-					[[EditableNSTextField alloc] initWithFrame:NSMakeRect(0, y, 200, 25)];
-		                [textfield setPlaceholderString:input];
+		                NSString *placeholder = input[@"Placeholder"];
+		                NSInteger type = [input[@"Type"] integerValue];
+		                NSTextField *textfield;
+		                if (type == 1) {
+		                        textfield = [[NSSecureTextField alloc] initWithFrame:NSMakeRect(0, y, 200, 25)];
+		                } else {
+		                        textfield = [[EditableNSTextField alloc] initWithFrame:NSMakeRect(0, y, 200, 25)];
+		                }
+		                [textfield setPlaceholderString:placeholder];
 		                [accessoryView addSubview:textfield];
 		                if (!first) {
 		                        [alert.window setInitialFirstResponder:textfield];
@@ -48,10 +54,10 @@ void showAlert(const char *jsonString) {
 		NSMutableArray *values = [NSMutableArray new];
 		if (hasInputs) {
 		        for (NSView *subview in accessoryView.subviews) {
-		                if (![subview isKindOfClass:[EditableNSTextField class]]) {
+		                if (![subview isKindOfClass:[NSTextField class]]) {
 		                        continue;
 				}
-		                [values addObject:((EditableNSTextField *)subview).stringValue];
+		                [values addObject:((NSTextField *)subview).stringValue];
 			}
 		}
 		NSData *jsonData =

--- a/alert_test.go
+++ b/alert_test.go
@@ -1,0 +1,79 @@
+package menuet
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestInputTypeConstants(t *testing.T) {
+	// The Objective-C side reads the Type field as an integer and compares
+	// against 1 for the password case (see alert.m). Lock the iota values
+	// in so future reordering doesn't silently swap the input rendering.
+	if InputText != 0 {
+		t.Errorf("InputText = %d, want 0", InputText)
+	}
+	if InputPassword != 1 {
+		t.Errorf("InputPassword = %d, want 1; alert.m checks `type == 1` for masked fields", InputPassword)
+	}
+}
+
+func TestAlertJSONIncludesInputType(t *testing.T) {
+	// The Alert value crosses the cgo boundary as JSON. Make sure the Type
+	// field is present on every input so a password input doesn't quietly
+	// degrade to a plain text field.
+	a := Alert{
+		MessageText: "Login",
+		Buttons:     []string{"OK", "Cancel"},
+		Inputs: []AlertInput{
+			{Placeholder: "Username"},
+			{Placeholder: "Password", Type: InputPassword},
+		},
+	}
+	b, err := json.Marshal(a)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	got := string(b)
+
+	// Both inputs should serialize their Type field, with the password
+	// input emitting Type:1.
+	wantSubstrings := []string{
+		`"Placeholder":"Username"`,
+		`"Type":0`,
+		`"Placeholder":"Password"`,
+		`"Type":1`,
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(got, want) {
+			t.Errorf("Alert JSON missing %q\nfull JSON: %s", want, got)
+		}
+	}
+}
+
+func TestAlertJSONRoundTripPreservesTypedInputs(t *testing.T) {
+	original := Alert{
+		MessageText: "Login",
+		Inputs: []AlertInput{
+			{Placeholder: "Username", Type: InputText},
+			{Placeholder: "Password", Type: InputPassword},
+		},
+	}
+	b, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	var round Alert
+	if err := json.Unmarshal(b, &round); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if len(round.Inputs) != 2 {
+		t.Fatalf("round-tripped %d inputs, want 2", len(round.Inputs))
+	}
+	if round.Inputs[0].Type != InputText {
+		t.Errorf("Inputs[0].Type = %d, want InputText (0)", round.Inputs[0].Type)
+	}
+	if round.Inputs[1].Type != InputPassword {
+		t.Errorf("Inputs[1].Type = %d, want InputPassword (1)", round.Inputs[1].Type)
+	}
+}

--- a/cmd/catalog/catalog.go
+++ b/cmd/catalog/catalog.go
@@ -21,17 +21,25 @@ var alertsCatalog = []menuet.Alert{
 	},
 	menuet.Alert{
 		MessageText: "Message and input",
-		Inputs:      []string{"Example input"},
+		Inputs:      []menuet.AlertInput{{Placeholder: "Example input"}},
 	},
 	menuet.Alert{
 		MessageText:     "Message, InformativeText, Button, and Input",
 		InformativeText: "Example InformativeText",
 		Buttons:         []string{"Example button"},
-		Inputs:          []string{"Example Input"},
+		Inputs:          []menuet.AlertInput{{Placeholder: "Example Input"}},
 	},
 	menuet.Alert{
 		MessageText: "Message and two inputs",
-		Inputs:      []string{"Input one", "Input two"},
+		Inputs:      []menuet.AlertInput{{Placeholder: "Input one"}, {Placeholder: "Input two"}},
+	},
+	menuet.Alert{
+		MessageText: "Login form",
+		Buttons:     []string{"Login", "Cancel"},
+		Inputs: []menuet.AlertInput{
+			{Placeholder: "Username"},
+			{Placeholder: "Password", Type: menuet.InputPassword},
+		},
 	},
 }
 

--- a/cmd/weather/weather.go
+++ b/cmd/weather/weather.go
@@ -149,7 +149,7 @@ func menuItems() []menuet.MenuItem {
 		Clicked: func() {
 			response := menuet.App().Alert(menuet.Alert{
 				MessageText: "Where would you like to display the weather for?",
-				Inputs:      []string{"Location"},
+				Inputs:      []menuet.AlertInput{{Placeholder: "Location"}},
 				Buttons:     []string{"Search", "Cancel"},
 			})
 			if response.Button == 0 && len(response.Inputs) == 1 && response.Inputs[0] != "" {


### PR DESCRIPTION
Cherry-pick of [dbeliakov/menuet@66fbad1](https://github.com/dbeliakov/menuet/commit/66fbad1), authorship preserved. Adds password-style masked input fields to \`Alert\` via a new \`AlertInput\` struct with a \`Type\` field.

## ⚠ Breaking API change

\`Alert.Inputs\` changes from \`[]string\` to \`[]AlertInput\`. Every consumer using the prior \`[]string\` shape needs a one-line update:

\`\`\`go
// Before (v1.x):
Inputs: []string{\"Location\"}

// After (v2.0.0):
Inputs: []menuet.AlertInput{{Placeholder: \"Location\"}}

// New capability:
Inputs: []menuet.AlertInput{
    {Placeholder: \"Username\"},
    {Placeholder: \"Password\", Type: menuet.InputPassword},
}
\`\`\`

The repo's two consumers (\`cmd/catalog\`, \`cmd/weather\`) are updated in the cherry-pick. README example block updated likewise.

## Tests

The Type field crosses the cgo boundary as JSON; alert.m reads it as an integer and checks \`type == 1\` to switch to \`NSSecureTextField\`. New \`alert_test.go\` locks this in:

  * \`TestInputTypeConstants\` — asserts \`InputText == 0\` and \`InputPassword == 1\`. Future iota reordering would silently swap which input gets masked, so this is load-bearing, not cosmetic.
  * \`TestAlertJSONIncludesInputType\` — asserts the JSON shape produced by \`Alert\` includes the Type field on every input.
  * \`TestAlertJSONRoundTripPreservesTypedInputs\` — round-trip sanity check.

\`go build ./...\`, \`go vet ./...\`, and \`go test ./...\` all clean.

## Release

Will tag \`v2.0.0\` after this PR merges (and likely after PR for the input-width follow-up).