### PR TITLE
Widen alert input fields from 200px to 300px

### DIFF
--- a/alert.m
+++ b/alert.m
@@ -28,16 +28,16 @@ void showAlert(const char *jsonString) {
 		if (hasInputs) {
 		        BOOL first = false;
 		        int y = 30 * inputs.count;
-		        accessoryView = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, 200, y)];
+		        accessoryView = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, 300, y)];
 		        for (NSDictionary *input in inputs) {
 		                y -= 30;
 		                NSString *placeholder = input[@"Placeholder"];
 		                NSInteger type = [input[@"Type"] integerValue];
 		                NSTextField *textfield;
 		                if (type == 1) {
-		                        textfield = [[NSSecureTextField alloc] initWithFrame:NSMakeRect(0, y, 200, 25)];
+		                        textfield = [[NSSecureTextField alloc] initWithFrame:NSMakeRect(0, y, 300, 25)];
 		                } else {
-		                        textfield = [[EditableNSTextField alloc] initWithFrame:NSMakeRect(0, y, 200, 25)];
+		                        textfield = [[EditableNSTextField alloc] initWithFrame:NSMakeRect(0, y, 300, 25)];
 		                }
 		                [textfield setPlaceholderString:placeholder];
 		                [accessoryView addSubview:textfield];


### PR DESCRIPTION
Cherry-pick of [dbeliakov/menuet@4ef1578](https://github.com/dbeliakov/menuet/commit/4ef1578). Pure UX adjustment to \`alert.m\` — input fields are now 300px wide instead of 200px, giving a more comfortable typing area for username/password/location/etc.

Bundling under v2.0.0 since alert.m is already being touched by the secure-input change in #27, and cosmetic widening doesn't deserve its own release.

No tests added — pixel widths in cgo UI code aren't usefully unit-testable.