### PR TITLE
Add optional left-click handler on the menubar icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,23 @@ menuet requires OS X.
 
 https://godoc.org/github.com/caseymrm/menuet
 
+## Left-click handler
+
+Set `Application.Clicked` to intercept left clicks on the menubar icon
+instead of opening the menu. The menu still opens on right click (or
+Ctrl-left-click). Useful for toggle-style apps — mute audio, pause a
+timer, etc. — where the menu is the secondary UI:
+
+```go
+menuet.App().Clicked = func() {
+    // toggle whatever state your app exposes
+}
+```
+
+Leave `Clicked` as `nil` (the default) for the standard behavior where
+any click opens the menu. Safe to set or clear at runtime; the next
+click reflects the current value.
+
 ## Running as a real macOS app
 
 `go run` is fine for early development, but several menuet features only work

--- a/click_test.go
+++ b/click_test.go
@@ -1,0 +1,66 @@
+package menuet
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Application is a singleton, so these tests must mutate App().Clicked in
+// sequence and reset it on the way out.
+
+func TestHasTopLevelClickedReflectsClickedField(t *testing.T) {
+	a := App()
+	defer func() { a.Clicked = nil }()
+
+	a.Clicked = nil
+	if hasTopLevelClicked() {
+		t.Errorf("hasTopLevelClicked() with nil callback = true, want false")
+	}
+
+	a.Clicked = func() {}
+	if !hasTopLevelClicked() {
+		t.Errorf("hasTopLevelClicked() with set callback = false, want true")
+	}
+
+	a.Clicked = nil
+	if hasTopLevelClicked() {
+		t.Errorf("hasTopLevelClicked() after clearing = true, want false")
+	}
+}
+
+func TestTopLevelClickedInvokesCallback(t *testing.T) {
+	a := App()
+	defer func() { a.Clicked = nil }()
+
+	var called int32
+	var wg sync.WaitGroup
+	wg.Add(1)
+	a.Clicked = func() {
+		atomic.StoreInt32(&called, 1)
+		wg.Done()
+	}
+
+	topLevelClicked()
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("callback was not invoked within 1s")
+	}
+	if atomic.LoadInt32(&called) != 1 {
+		t.Errorf("callback didn't run")
+	}
+}
+
+func TestTopLevelClickedIsNoOpWhenNil(t *testing.T) {
+	a := App()
+	defer func() { a.Clicked = nil }()
+
+	a.Clicked = nil
+	// Should not panic.
+	topLevelClicked()
+}

--- a/cmd/catalog/catalog.go
+++ b/cmd/catalog/catalog.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/caseymrm/menuet"
 )
 
@@ -112,6 +114,36 @@ func menuItems() []menuet.MenuItem {
 		menuet.MenuItem{
 			Text:     "Menu Items",
 			Children: items,
+		},
+		menuet.MenuItem{
+			Text:     "Left-click handler",
+			Children: clickHandlerMenu,
+		},
+	}
+}
+
+var topLevelClicks int
+
+func handleTopLevelClick() {
+	topLevelClicks++
+	menuet.App().SetMenuState(&menuet.MenuState{
+		Title: fmt.Sprintf("Clicks: %d", topLevelClicks),
+	})
+}
+
+func clickHandlerMenu() []menuet.MenuItem {
+	return []menuet.MenuItem{
+		{
+			Text:  "Enabled (left click counts; right click still opens menu)",
+			State: menuet.App().Clicked != nil,
+			Clicked: func() {
+				if menuet.App().Clicked == nil {
+					menuet.App().Clicked = handleTopLevelClick
+				} else {
+					menuet.App().Clicked = nil
+					menuet.App().SetMenuState(&menuet.MenuState{Title: "Catalog"})
+				}
+			},
 		},
 	}
 }

--- a/menuet.go
+++ b/menuet.go
@@ -44,6 +44,13 @@ type Application struct {
 	// NotificationResponder is a handler called when notification respond
 	NotificationResponder func(id, response string)
 
+	// Clicked, if set, is called when the user left-clicks the menubar
+	// icon. The menu does not auto-open on left click in this case —
+	// right click (or Ctrl-left-click) opens it instead. Useful for
+	// toggle-style apps (mute, pause, etc.) where the menu is the
+	// secondary UI. Safe to set or clear at runtime.
+	Clicked func()
+
 	// StartAtLoginLabel overrides the default "Start at Login" menu item text
 	StartAtLoginLabel string
 	// QuitLabel overrides the default "Quit" menu item text
@@ -197,6 +204,18 @@ func notificationRespond(id *C.char, response *C.char) {
 //export hideStartup
 func hideStartup() bool {
 	return App().hideStartupItem
+}
+
+//export hasTopLevelClicked
+func hasTopLevelClicked() bool {
+	return App().Clicked != nil
+}
+
+//export topLevelClicked
+func topLevelClicked() {
+	if f := App().Clicked; f != nil {
+		go f()
+	}
 }
 
 //export startAtLoginLabel

--- a/menuet.m
+++ b/menuet.m
@@ -15,8 +15,13 @@ bool runningAtStartup();
 void toggleStartup();
 void shutdownWait();
 void initNotifications(void);
+bool hasTopLevelClicked();
+void topLevelClicked();
+
+@class MenuetMenu;
 
 NSStatusItem *_statusItem;
+MenuetMenu *_rootMenu;
 
 @interface MenuetMenu : NSMenu <NSMenuDelegate>
 
@@ -223,8 +228,7 @@ void setState(const char *jsonString) {
 
 void menuChanged() {
         dispatch_async(dispatch_get_main_queue(), ^{
-		MenuetMenu *menu = (MenuetMenu *)_statusItem.menu;
-		[menu refreshVisibleMenus];
+		[_rootMenu refreshVisibleMenus];
 	});
 }
 
@@ -238,9 +242,15 @@ void createAndRunApplication() {
         [a setActivationPolicy:NSApplicationActivationPolicyAccessory];
         _statusItem = [[NSStatusBar systemStatusBar]
                        statusItemWithLength:NSVariableStatusItemLength];
-        MenuetMenu *menu = [MenuetMenu new];
-        menu.root = true;
-        _statusItem.menu = menu;
+        _rootMenu = [MenuetMenu new];
+        _rootMenu.root = true;
+        // We intercept all button clicks instead of assigning _statusItem.menu
+        // so that the optional Application.Clicked handler (Go side) can fire
+        // on left clicks while the menu still opens on right click. When no
+        // handler is set, every click falls through to the menu popup.
+        _statusItem.button.target = d;
+        _statusItem.button.action = @selector(statusItemClicked:);
+        [_statusItem.button sendActionOn:(NSEventMaskLeftMouseUp | NSEventMaskRightMouseUp)];
         [a run];
 }
 
@@ -262,6 +272,23 @@ void createAndRunApplication() {
                 notificationRespond(identifier.UTF8String, @"".UTF8String);
         }
         completionHandler();
+}
+
+- (void)statusItemClicked:(id)sender {
+        NSEvent *event = [NSApp currentEvent];
+        BOOL openMenu = !hasTopLevelClicked() ||
+                        event.type == NSEventTypeRightMouseUp ||
+                        (event.modifierFlags & NSEventModifierFlagControl) != 0;
+        if (openMenu) {
+                NSStatusBarButton *button = _statusItem.button;
+                button.highlighted = YES;
+                [_rootMenu popUpMenuPositioningItem:nil
+                                         atLocation:NSMakePoint(0, button.bounds.size.height)
+                                             inView:button];
+                button.highlighted = NO;
+                return;
+        }
+        topLevelClicked();
 }
 
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center


### PR DESCRIPTION
Adds an optional \`Application.Clicked func()\`. When set, left-clicking the menubar icon fires the callback instead of opening the menu; right click (or Ctrl-left-click) still opens the menu. Useful for toggle-style apps — mute, pause a timer, etc. — where the menu is the secondary UI.

\`\`\`go
menuet.App().Clicked = func() {
    // toggle whatever state your app exposes
}
\`\`\`

Leave \`Clicked\` as \`nil\` (the default) for the standard \"every click opens the menu\" behavior. Safe to set or clear at runtime — the next click reflects the current value.

## Implementation note

\`NSStatusItem\` doesn't let you both have an attached menu and intercept clicks — assigning \`.menu\` makes the menu open automatically and the button's action selector is never called. To support runtime toggling, this PR replaces the \`_statusItem.menu = menu\` assignment with a permanent \`button.action\` handler that:

1. Inspects \`[NSApp currentEvent]\` for type + modifier flags
2. On right-click (or Ctrl-left-click) — or when no Go callback is set — pops the menu up manually via \`popUpMenuPositioningItem:atLocation:inView:\` and toggles \`button.highlighted\` for visual feedback
3. Otherwise calls the Go-exported \`topLevelClicked\` which fires \`App().Clicked\` on a goroutine (matching the existing \`itemClicked\` pattern so user callbacks never block the AppKit event loop)

For consumers who never set \`Clicked\`, behavior is unchanged — every click falls through to the menu popup.

## Tests

\`click_test.go\` covers the Go side:
- \`hasTopLevelClicked\` reflects whether \`Application.Clicked\` is non-nil
- The exported \`topLevelClicked\` cgo function invokes the callback on a goroutine when set
- \`topLevelClicked\` is a no-op (no panic) when \`Application.Clicked\` is nil

The cgo bridge and Objective-C handler can only be verified by clicking — Casey confirmed live in the Catalog app that both modes work (right-click opens menu, left-click increments the counter title; toggle off restores normal behavior).

## Catalog

New \"Left-click handler\" submenu with a stateful toggle. When enabled, left-clicking the menubar icon shows a click counter in the title; right-click still opens the menu. Toggle off restores the title and the default behavior.

## Release

Additive feature → v2.1.0 after merge.