### PR TITLE
Fix v2 module path for Go modules compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Under active development. API still changing rapidly.
 ## Installation
 menuet requires OS X.
 
-`go get github.com/caseymrm/menuet`
+`go get github.com/caseymrm/menuet/v2`
 
 ## Documentation
 
@@ -90,7 +90,7 @@ package main
 import (
 	"time"
 
-	"github.com/caseymrm/menuet"
+	"github.com/caseymrm/menuet/v2"
 )
 
 func helloClock() {
@@ -132,7 +132,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/caseymrm/menuet"
+	"github.com/caseymrm/menuet/v2"
 )
 
 func temperature(woeid string) (temp, unit, text string) {

--- a/cmd/catalog/catalog.go
+++ b/cmd/catalog/catalog.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/caseymrm/menuet"
+	"github.com/caseymrm/menuet/v2"
 )
 
 var alertsCatalog = []menuet.Alert{

--- a/cmd/helloworld/helloworld.go
+++ b/cmd/helloworld/helloworld.go
@@ -3,7 +3,7 @@ package main
 import (
 	"time"
 
-	"github.com/caseymrm/menuet"
+	"github.com/caseymrm/menuet/v2"
 )
 
 func helloClock() {

--- a/cmd/slowquit/slowquit.go
+++ b/cmd/slowquit/slowquit.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/caseymrm/menuet"
+	"github.com/caseymrm/menuet/v2"
 )
 
 func main() {

--- a/cmd/weather/weather.go
+++ b/cmd/weather/weather.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/caseymrm/menuet"
+	"github.com/caseymrm/menuet/v2"
 )
 
 func temperature(woeid string) (temp, unit, text string) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/caseymrm/menuet
+module github.com/caseymrm/menuet/v2
 
 go 1.13
 


### PR DESCRIPTION
## Summary

Go modules require the module path to end in `/vN` for any version v2 or higher. We tagged `v2.0.0` and `v2.1.0` on master, but `go.mod` still declared `module github.com/caseymrm/menuet` (no `/v2` suffix). The result is that those tags exist but are unimportable -- `go get github.com/caseymrm/menuet@v2.x.x` fails with a "module path does not match" error, and there is no working import path for the v2 line.

This PR makes those existing v2 tags actually usable:

- Bump module path in `go.mod` to `github.com/caseymrm/menuet/v2`
- Update the four example apps under `cmd/` (catalog, helloworld, slowquit, weather) to import the versioned path
- Update the `go get` line and example imports in `README.md`

No code behavior changes -- only the module identifier and the import strings that point at it. `menuet.mk` is left alone; its `$(GOPATH)/src/github.com/caseymrm/menuet` reference is a filesystem path, not an import path, and Go tooling resolves a `/v2` module to the same on-disk directory.

A follow-up `v2.1.1` tag will be cut from master after this merges so consumers finally have an importable v2 release. v2.0.0 / v2.1.0 functionality is unchanged -- they were just unreachable.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` green (~0.3s, no network)
- [x] No unversioned `github.com/caseymrm/menuet` import remains in any `.go` file