### PR TITLE
v2.2.0: MenuItem becomes an interface; add Regular and Separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,27 @@ func main() {
 
 ![Output](https://github.com/caseymrm/menuet/raw/master/static/helloworld.gif)
 
+## Menu items
+
+`MenuItem` is an interface; the concrete types are `Regular` (a normal row)
+and `Separator` (a horizontal divider). Construct a menu by returning a
+`[]menuet.MenuItem` containing whichever concrete types you need:
+
+```go
+menuet.App().Children = func() []menuet.MenuItem {
+    return []menuet.MenuItem{
+        menuet.Regular{Text: "Status: Active"},
+        menuet.Separator{},
+        menuet.Regular{Text: "Refresh", Clicked: refresh},
+        menuet.Regular{Text: "Submenu", Children: subItems},
+    }
+}
+```
+
+`Regular` carries the familiar fields — `Text`, `Image`, `FontSize`,
+`FontWeight`, `State`, `Clicked`, `Children`. Setting `Clicked` makes it
+clickable; setting `Children` makes it a submenu.
+
 ## [Catalog](https://github.com/caseymrm/menuet/tree/master/cmd/catalog)
 
 The catalog app is useful for trying many of the possible combinations of features.
@@ -220,7 +241,7 @@ var woeids = map[int]string{
 func menuPreview(woeid string) func() []menuet.MenuItem {
 	return func() []menuet.MenuItem {
 		return []menuet.MenuItem{
-			menuet.MenuItem{
+			menuet.Regular{
 				Text: temperatureString(woeid),
 				Clicked: func() {
 					setLocation(woeid)
@@ -241,7 +262,7 @@ func menuItems() []menuet.MenuItem {
 	found := false
 	for woeid, name := range woeids {
 		woeStr := strconv.Itoa(woeid)
-		items = append(items, menuet.MenuItem{
+		items = append(items, menuet.Regular{
 			Text: name,
 			Clicked: func() {
 				setLocation(woeStr)
@@ -254,7 +275,7 @@ func menuItems() []menuet.MenuItem {
 		}
 	}
 	if !found {
-		items = append(items, menuet.MenuItem{
+		items = append(items, menuet.Regular{
 			Text: menuet.Defaults().String("name"),
 			Clicked: func() {
 				setLocation(currentWoeid)
@@ -264,9 +285,9 @@ func menuItems() []menuet.MenuItem {
 		})
 	}
 	sort.Slice(items, func(i, j int) bool {
-		return items[i].Text < items[j].Text
+		return items[i].(menuet.Regular).Text < items[j].(menuet.Regular).Text
 	})
-	items = append(items, menuet.MenuItem{
+	items = append(items, menuet.Regular{
 		Text: "Other...",
 		Clicked: func() {
 			response := menuet.App().Alert(menuet.Alert{

--- a/cmd/catalog/catalog.go
+++ b/cmd/catalog/catalog.go
@@ -99,23 +99,23 @@ var notificationsCatalog = []menuet.Notification{
 
 func menuItems() []menuet.MenuItem {
 	return []menuet.MenuItem{
-		menuet.MenuItem{
+		menuet.Regular{
 			Text:     "Show Alert",
 			Children: alerts,
 		},
-		menuet.MenuItem{
+		menuet.Regular{
 			Text:     "Send Notification",
 			Children: notifs,
 		},
-		menuet.MenuItem{
+		menuet.Regular{
 			Text:     "Change Title",
 			Children: changeTitle,
 		},
-		menuet.MenuItem{
+		menuet.Regular{
 			Text:     "Menu Items",
 			Children: items,
 		},
-		menuet.MenuItem{
+		menuet.Regular{
 			Text:     "Left-click handler",
 			Children: clickHandlerMenu,
 		},
@@ -133,7 +133,7 @@ func handleTopLevelClick() {
 
 func clickHandlerMenu() []menuet.MenuItem {
 	return []menuet.MenuItem{
-		{
+		menuet.Regular{
 			Text:  "Enabled (left click counts; right click still opens menu)",
 			State: menuet.App().Clicked != nil,
 			Clicked: func() {
@@ -156,7 +156,7 @@ func alerts() []menuet.MenuItem {
 		if text == "" {
 			text = alert.InformativeText
 		}
-		alerts = append(alerts, menuet.MenuItem{
+		alerts = append(alerts, menuet.Regular{
 			Text: text,
 			Clicked: func() {
 				menuet.App().Alert(alert)
@@ -177,7 +177,7 @@ func notifs() []menuet.MenuItem {
 		if text == "" {
 			text = notif.Message
 		}
-		notifs = append(notifs, menuet.MenuItem{
+		notifs = append(notifs, menuet.Regular{
 			Text: text,
 			Clicked: func() {
 				menuet.App().Notification(notif)
@@ -189,7 +189,7 @@ func notifs() []menuet.MenuItem {
 
 func changeTitle() []menuet.MenuItem {
 	return []menuet.MenuItem{
-		{
+		menuet.Regular{
 			Text: "Text only",
 			Clicked: func() {
 				menuet.App().SetMenuState(&menuet.MenuState{
@@ -197,7 +197,7 @@ func changeTitle() []menuet.MenuItem {
 				})
 			},
 		},
-		{
+		menuet.Regular{
 			Text: "Image only",
 			Clicked: func() {
 				menuet.App().SetMenuState(&menuet.MenuState{
@@ -205,7 +205,7 @@ func changeTitle() []menuet.MenuItem {
 				})
 			},
 		},
-		{
+		menuet.Regular{
 			Text: "Text and Image",
 			Clicked: func() {
 				menuet.App().SetMenuState(&menuet.MenuState{
@@ -219,22 +219,22 @@ func changeTitle() []menuet.MenuItem {
 
 func items() []menuet.MenuItem {
 	return []menuet.MenuItem{
-		{
+		menuet.Regular{
 			Text: "Just text",
 		},
-		{
+		menuet.Regular{
 			Text:     "FontSizes",
 			Children: fontsizes,
 		},
-		{
+		menuet.Regular{
 			Text:     "FontWeights",
 			Children: fontweights,
 		},
-		{
+		menuet.Regular{
 			Text:  "State = true",
 			State: true,
 		},
-		{
+		menuet.Regular{
 			Text: "Text and Clicked",
 			Clicked: func() {
 				menuet.App().Alert(menuet.Alert{
@@ -242,23 +242,23 @@ func items() []menuet.MenuItem {
 				})
 			},
 		},
-		{
+		menuet.Regular{
 			Text: "Text and Children",
 			Children: func() []menuet.MenuItem {
 				return []menuet.MenuItem{
-					{
+					menuet.Regular{
 						Text: "Hello",
 					},
-					{
+					menuet.Regular{
 						Text: "Inline",
 					},
-					{
+					menuet.Regular{
 						Text: "Children",
 					},
 				}
 			},
 		},
-		{
+		menuet.Regular{
 			Text:  "Text, Image, and Clicked",
 			Image: "clipboard",
 			Clicked: func() {
@@ -267,83 +267,83 @@ func items() []menuet.MenuItem {
 				})
 			},
 		},
-		{
+		menuet.Regular{
 			Text:  "Text, Image, and Children",
 			Image: "clipboard",
 			Children: func() []menuet.MenuItem {
 				return []menuet.MenuItem{
-					{
+					menuet.Regular{
 						Text: "Hello",
 					},
-					{
+					menuet.Regular{
 						Text: "Inline",
 					},
-					{
+					menuet.Regular{
 						Text: "Children",
 					},
 				}
 			},
 		},
-		{
+		menuet.Regular{
 			Text:  "Image and Text",
 			Image: "clipboard",
 		},
-		{
+		menuet.Regular{
 			Image: "clipboard",
 		},
 	}
 }
 func fontsizes() []menuet.MenuItem {
 	return []menuet.MenuItem{
-		{
+		menuet.Regular{
 			Text:     "FontSize 2",
 			FontSize: 2,
 		},
-		{
+		menuet.Regular{
 			Text:     "FontSize 4",
 			FontSize: 4,
 		},
-		{
+		menuet.Regular{
 			Text:     "FontSize 6",
 			FontSize: 6,
 		},
-		{
+		menuet.Regular{
 			Text:     "FontSize 8",
 			FontSize: 8,
 		},
-		{
+		menuet.Regular{
 			Text:     "FontSize 10",
 			FontSize: 10,
 		},
-		{
+		menuet.Regular{
 			Text:     "FontSize 12",
 			FontSize: 12,
 		},
-		{
+		menuet.Regular{
 			Text:     "FontSize 14",
 			FontSize: 14,
 		},
-		{
+		menuet.Regular{
 			Text:     "FontSize 16",
 			FontSize: 16,
 		},
-		{
+		menuet.Regular{
 			Text:     "FontSize 18",
 			FontSize: 18,
 		},
-		{
+		menuet.Regular{
 			Text:     "FontSize 20",
 			FontSize: 20,
 		},
-		{
+		menuet.Regular{
 			Text:     "FontSize 22",
 			FontSize: 22,
 		},
-		{
+		menuet.Regular{
 			Text:     "FontSize 24",
 			FontSize: 24,
 		},
-		{
+		menuet.Regular{
 			Text:     "FontSize 26",
 			FontSize: 26,
 		},
@@ -352,39 +352,39 @@ func fontsizes() []menuet.MenuItem {
 
 func fontweights() []menuet.MenuItem {
 	return []menuet.MenuItem{
-		{
+		menuet.Regular{
 			Text:       "WeightUltraLight",
 			FontWeight: menuet.WeightUltraLight,
 		},
-		{
+		menuet.Regular{
 			Text:       "WeightThin",
 			FontWeight: menuet.WeightThin,
 		},
-		{
+		menuet.Regular{
 			Text:       "WeightLight",
 			FontWeight: menuet.WeightLight,
 		},
-		{
+		menuet.Regular{
 			Text:       "WeightRegular",
 			FontWeight: menuet.WeightRegular,
 		},
-		{
+		menuet.Regular{
 			Text:       "WeightMedium",
 			FontWeight: menuet.WeightMedium,
 		},
-		{
+		menuet.Regular{
 			Text:       "WeightSemibold",
 			FontWeight: menuet.WeightSemibold,
 		},
-		{
+		menuet.Regular{
 			Text:       "WeightBold",
 			FontWeight: menuet.WeightBold,
 		},
-		{
+		menuet.Regular{
 			Text:       "WeightHeavy",
 			FontWeight: menuet.WeightHeavy,
 		},
-		{
+		menuet.Regular{
 			Text:       "WeightBlack",
 			FontWeight: menuet.WeightBlack,
 		},

--- a/cmd/weather/weather.go
+++ b/cmd/weather/weather.go
@@ -98,7 +98,7 @@ var woeids = map[int]string{
 func menuPreview(woeid string) func() []menuet.MenuItem {
 	return func() []menuet.MenuItem {
 		return []menuet.MenuItem{
-			menuet.MenuItem{
+			menuet.Regular{
 				Text: temperatureString(woeid),
 				Clicked: func() {
 					setLocation(woeid)
@@ -119,7 +119,7 @@ func menuItems() []menuet.MenuItem {
 	found := false
 	for woeid, name := range woeids {
 		woeStr := strconv.Itoa(woeid)
-		items = append(items, menuet.MenuItem{
+		items = append(items, menuet.Regular{
 			Text: name,
 			Clicked: func() {
 				setLocation(woeStr)
@@ -132,7 +132,7 @@ func menuItems() []menuet.MenuItem {
 		}
 	}
 	if !found {
-		items = append(items, menuet.MenuItem{
+		items = append(items, menuet.Regular{
 			Text: menuet.Defaults().String("name"),
 			Clicked: func() {
 				setLocation(currentWoeid)
@@ -142,9 +142,9 @@ func menuItems() []menuet.MenuItem {
 		})
 	}
 	sort.Slice(items, func(i, j int) bool {
-		return items[i].Text < items[j].Text
+		return items[i].(menuet.Regular).Text < items[j].(menuet.Regular).Text
 	})
-	items = append(items, menuet.MenuItem{
+	items = append(items, menuet.Regular{
 		Text: "Other...",
 		Clicked: func() {
 			response := menuet.App().Alert(menuet.Alert{

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,9 @@ module github.com/caseymrm/menuet/v2
 go 1.13
 
 require github.com/caseymrm/askm v1.0.0
+
+retract (
+	v2.0.0 // unimportable — module path was missing /v2 suffix
+	v2.1.0 // unimportable — module path was missing /v2 suffix
+	v2.1.1 // superseded by v2.2.0 — MenuItem became an interface
+)

--- a/menuet.go
+++ b/menuet.go
@@ -163,9 +163,10 @@ func (a *Application) clicked(unique string) {
 	a.visibleMenuItemsMutex.RUnlock()
 	if !ok {
 		log.Printf("Item not found for click: %s", unique)
+		return
 	}
-	if item.Clicked != nil {
-		go item.Clicked()
+	if reg, ok := item.item.(Regular); ok && reg.Clicked != nil {
+		go reg.Clicked()
 	}
 }
 

--- a/menuitem.go
+++ b/menuitem.go
@@ -8,85 +8,107 @@ import (
 	"github.com/caseymrm/askm"
 )
 
-// ItemType represents what type of menu item this is
-type ItemType string
+// MenuItem is the marker interface for items in a menu.
+// The concrete types in this package implement it: Regular and Separator.
+// A future Search type for in-menu search fields will implement it too.
+type MenuItem interface {
+	menuItem()
+}
 
-const (
-	// Regular is a normal item with text and optional callback
-	Regular ItemType = ""
-	// Separator is a horizontal line
-	Separator = "separator"
-	// Root is the top level menu directly off the menubar
-	Root = "root"
-	// TODO: StartAtLogin, Quit, Image, Spinner, etc
-)
-
-// MenuItem represents one item in the dropdown
-type MenuItem struct {
-	Type ItemType
-
+// Regular is a standard menu row. Set Text and optionally Clicked
+// (callback when activated) and Children (returns a submenu).
+type Regular struct {
 	Text       string
 	Image      string // In Resources dir or URL, should have height 16
 	FontSize   int    // Default: 14
 	FontWeight FontWeight
 	State      bool // shows checkmark when set
 
-	Clicked  func()            `json:"-"`
-	Children func() []MenuItem `json:"-"`
+	Clicked  func()
+	Children func() []MenuItem
 }
+
+func (Regular) menuItem() {}
+
+// Separator is a horizontal divider between menu rows.
+type Separator struct{}
+
+func (Separator) menuItem() {}
 
 type internalItem struct {
 	Unique       string
 	ParentUnique string
-	HasChildren  bool
-	Clickable    bool
 
-	MenuItem
+	// Fields serialized to the ObjC side. The shape is intentionally flat
+	// so the existing populate: in menuet.m doesn't need to know about
+	// MenuItem types — it just reads Type and the matching fields.
+	Type        string
+	Text        string
+	Image       string
+	FontSize    int
+	FontWeight  FontWeight
+	State       bool
+	HasChildren bool
+	Clickable   bool
+
+	// item is the original MenuItem, kept so click and Children callbacks
+	// can be looked up later when ObjC re-enters via itemClicked / children.
+	item MenuItem
+}
+
+func buildInternalItem(item MenuItem, unique, parentUnique string) internalItem {
+	out := internalItem{Unique: unique, ParentUnique: parentUnique, item: item}
+	switch v := item.(type) {
+	case Regular:
+		out.Text = v.Text
+		out.Image = v.Image
+		out.FontSize = v.FontSize
+		out.FontWeight = v.FontWeight
+		out.State = v.State
+		out.Clickable = v.Clicked != nil
+		out.HasChildren = v.Children != nil
+	case Separator:
+		out.Type = "separator"
+	}
+	return out
 }
 
 func (a *Application) children(unique string) []internalItem {
 	a.visibleMenuItemsMutex.RLock()
-	item, ok := a.visibleMenuItems[unique]
+	parent, ok := a.visibleMenuItems[unique]
 	a.visibleMenuItemsMutex.RUnlock()
+
+	var childrenFn func() []MenuItem
 	if strings.HasSuffix(unique, ":root") {
-		// Create synthetic item
-		item.Unique = unique
-		item.Type = Root
-		item.Children = a.Children
-		ok = true
-	}
-	if !ok {
+		childrenFn = a.Children
+	} else if ok {
+		if reg, regOK := parent.item.(Regular); regOK {
+			childrenFn = reg.Children
+		}
+	} else {
 		log.Printf("Item not found for children: %s", unique)
 	}
-	var items []MenuItem
-	if item.Children != nil {
-		items = item.Children()
+	if childrenFn == nil {
+		return nil
 	}
+
+	items := childrenFn()
 	internalItems := make([]internalItem, len(items))
+	a.visibleMenuItemsMutex.Lock()
+	defer a.visibleMenuItemsMutex.Unlock()
 	for ind, item := range items {
-		a.visibleMenuItemsMutex.Lock()
 		newUnique := askm.ArbitraryKeyNotInMap(a.visibleMenuItems)
-		internal := internalItem{
-			Unique:       newUnique,
-			ParentUnique: unique,
-			MenuItem:     item,
-		}
-		if internal.Children != nil {
-			internal.HasChildren = true
-		}
-		if internal.Clicked != nil {
-			internal.Clickable = true
-		}
+		internal := buildInternalItem(item, newUnique, unique)
 		a.visibleMenuItems[newUnique] = internal
 		internalItems[ind] = internal
-		a.visibleMenuItemsMutex.Unlock()
 	}
 	return internalItems
 }
 
 func (a *Application) menuClosed(unique string) {
 	go func() {
-		// We receive menuClosed before clicked, so wait a second before discarding the data just in case
+		// We receive menuClosed before clicked, so wait a moment before
+		// discarding the data just in case a click is in flight.
 		time.Sleep(100 * time.Millisecond)
 		a.visibleMenuItemsMutex.Lock()
 		for itemUnique, item := range a.visibleMenuItems {


### PR DESCRIPTION
First of two PRs setting up for the in-menu search feature. This one is the type refactor; the next adds \`Search\`.

## What changes

\`MenuItem\` becomes a marker interface. \`Regular\` and \`Separator\` are the first two concrete types implementing it:

\`\`\`go
// Before
[]menuet.MenuItem{
    menuet.MenuItem{Text: \"Refresh\", Clicked: refresh},
    menuet.MenuItem{Type: menuet.Separator},
}

// After
[]menuet.MenuItem{
    menuet.Regular{Text: \"Refresh\", Clicked: refresh},
    menuet.Separator{},
}
\`\`\`

Why now: with \`Search\` coming next (its own \`Search func(query string) []MenuItem\` callback), the \"one struct with conditional fields per Type\" pattern was about to gain a fourth function-type field. The interface shape lets each menu item carry only what makes sense, and lets the compiler catch \"you set \`Clicked\` on a \`Separator\`\" mistakes at the call site.

## Migration

For consumers (just Casey right now):
- \`menuet.MenuItem{Text: \"...\"}\` → \`menuet.Regular{Text: \"...\"}\`
- Bare struct literals in \`[]menuet.MenuItem\` slices must qualify the type (Go can't infer the concrete type for interface elements)
- Sorting by a field requires a type assertion: \`items[i].(menuet.Regular).Text\`

The Objective-C side is untouched — every concrete type marshals into the same flat JSON shape menuet.m already reads.

## Retraction strategy

Per Go modules conventions, an in-place breaking change to a v2.x line would violate semver. Two of the three prior v2 tags (v2.0.0, v2.1.0) were already unimportable due to the missing \`/v2\` module path. v2.1.1 was the first usable one but is now superseded.

\`go.mod\` adds:

\`\`\`go
retract (
    v2.0.0 // unimportable — module path was missing /v2 suffix
    v2.1.0 // unimportable — module path was missing /v2 suffix
    v2.1.1 // superseded by v2.2.0 — MenuItem became an interface
)
\`\`\`

Effect: \`go get menuet@latest\` skips the retracted versions; explicit \`@v2.1.1\` still works but warns. v2.2.0 is the de-facto first usable v2.

## Verification

- \`go build ./...\`, \`go vet ./...\`, \`go test ./...\` all clean
- All existing tests pass unchanged (startup, autoupdate, alert JSON, click handler)
- Catalog rebuilt and verified interactively — menus render, submenus work, clicks fire, separators look right

## Next

PR 2 will add the \`Search\` type (concrete \`menuet.Search{Placeholder, Results}\`), the Carbon event handler for in-menu keystroke capture, the \`respondsToSelector:\` wrapper for \`[NSMenu highlightItem:]\`, and a catalog demo. Tagging v2.3.0 after that lands.