### PR TITLE
v2.3.0: Add menuet.Search MenuItem type

### DIFF
--- a/cmd/catalog/catalog.go
+++ b/cmd/catalog/catalog.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/caseymrm/menuet/v2"
 )
@@ -118,6 +119,58 @@ func menuItems() []menuet.MenuItem {
 		menuet.Regular{
 			Text:     "Left-click handler",
 			Children: clickHandlerMenu,
+		},
+		menuet.Regular{
+			Text:     "Search",
+			Children: searchDemo,
+		},
+	}
+}
+
+// searchDemo shows a submenu containing a Search field over a static
+// list of US states. The Results callback runs on every keystroke; for
+// this demo it does a simple case-insensitive substring match, but the
+// signature gives you the query string so a real app can do HTTP
+// lookups, fuzzy matching, etc.
+var demoStates = []string{
+	"Alabama", "Alaska", "Arizona", "Arkansas", "California",
+	"Colorado", "Connecticut", "Delaware", "Florida", "Georgia",
+	"Hawaii", "Idaho", "Illinois", "Indiana", "Iowa", "Kansas",
+	"Kentucky", "Louisiana", "Maine", "Maryland", "Massachusetts",
+	"Michigan", "Minnesota", "Mississippi", "Missouri", "Montana",
+	"Nebraska", "Nevada", "New Hampshire", "New Jersey", "New Mexico",
+	"New York", "North Carolina", "North Dakota", "Ohio", "Oklahoma",
+	"Oregon", "Pennsylvania", "Rhode Island", "South Carolina",
+	"South Dakota", "Tennessee", "Texas", "Utah", "Vermont",
+	"Virginia", "Washington", "West Virginia", "Wisconsin", "Wyoming",
+}
+
+func searchDemo() []menuet.MenuItem {
+	return []menuet.MenuItem{
+		menuet.Search{
+			Placeholder: "Filter US states…",
+			Results: func(query string) []menuet.MenuItem {
+				q := strings.ToLower(query)
+				out := make([]menuet.MenuItem, 0, len(demoStates))
+				for _, name := range demoStates {
+					if q != "" && !strings.Contains(strings.ToLower(name), q) {
+						continue
+					}
+					state := name
+					out = append(out, menuet.Regular{
+						Text: state,
+						Clicked: func() {
+							menuet.App().Alert(menuet.Alert{
+								MessageText: "You picked " + state,
+							})
+						},
+					})
+					if len(out) >= 20 {
+						break
+					}
+				}
+				return out
+			},
 		},
 	}
 }

--- a/docs/research/nsmenu_probe.m
+++ b/docs/research/nsmenu_probe.m
@@ -1,0 +1,98 @@
+// Probe AppKit's NSMenu / NSMenuItem / NSPopupMenuWindow for any private
+// selectors that look related to search, filtering, highlight, or focus.
+// Build:  clang -framework Cocoa -framework AppKit nsmenu_probe.m -o nsmenu_probe
+// Run:    ./nsmenu_probe
+
+#import <Cocoa/Cocoa.h>
+#import <objc/runtime.h>
+
+static void dumpClass(const char *name, NSString *grep) {
+    Class cls = objc_getClass(name);
+    if (!cls) {
+        printf("=== %s NOT FOUND ===\n", name);
+        return;
+    }
+    printf("=== %s instance methods matching /%s/ ===\n", name, grep.UTF8String);
+
+    // Walk the class chain to catch methods inherited from private internals.
+    Class current = cls;
+    while (current && current != [NSObject class]) {
+        unsigned int count = 0;
+        Method *methods = class_copyMethodList(current, &count);
+        for (unsigned int i = 0; i < count; i++) {
+            const char *sel = sel_getName(method_getName(methods[i]));
+            NSString *s = [NSString stringWithUTF8String:sel];
+            if ([s rangeOfString:grep options:NSCaseInsensitiveSearch].location != NSNotFound) {
+                printf("  %s :: %s\n", class_getName(current), sel);
+            }
+        }
+        free(methods);
+        current = class_getSuperclass(current);
+    }
+
+    printf("=== %s class methods matching /%s/ ===\n", name, grep.UTF8String);
+    current = object_getClass(cls);
+    while (current && current != object_getClass([NSObject class])) {
+        unsigned int count = 0;
+        Method *methods = class_copyMethodList(current, &count);
+        for (unsigned int i = 0; i < count; i++) {
+            const char *sel = sel_getName(method_getName(methods[i]));
+            NSString *s = [NSString stringWithUTF8String:sel];
+            if ([s rangeOfString:grep options:NSCaseInsensitiveSearch].location != NSNotFound) {
+                printf("  +[%s %s]\n", class_getName(current), sel);
+            }
+        }
+        free(methods);
+        current = class_getSuperclass(current);
+    }
+}
+
+static void listAllAppKitClasses(NSString *grep) {
+    printf("=== AppKit classes matching /%s/ ===\n", grep.UTF8String);
+    unsigned int total = 0;
+    int *classes = (int *)objc_copyClassNamesForImage(
+        "/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit", &total);
+    if (!classes) {
+        // dyld_shared_cache path on newer macOS
+        printf("(no image-specific class list; falling back to objc_getClassList)\n");
+        int count = objc_getClassList(NULL, 0);
+        Class *all = (Class *)malloc(sizeof(Class) * count);
+        objc_getClassList(all, count);
+        for (int i = 0; i < count; i++) {
+            const char *n = class_getName(all[i]);
+            NSString *s = [NSString stringWithUTF8String:n];
+            if ([s rangeOfString:grep options:NSCaseInsensitiveSearch].location != NSNotFound) {
+                printf("  %s\n", n);
+            }
+        }
+        free(all);
+        return;
+    }
+    free(classes);
+}
+
+int main(int argc, char *argv[]) {
+    @autoreleasepool {
+        // Names of interest
+        const char *targets[] = {
+            "NSMenu", "NSMenuItem", "NSPopupMenuWindow", "NSCarbonMenuImpl",
+            "NSMenuTrackingData", "NSContextMenuImpl", "NSHelpManager",
+            "NSCarbonMenuWindow", "NSMenuView",
+        };
+        NSArray<NSString *> *greps = @[
+            @"search", @"filter", @"highlight",
+            @"track", @"key", @"first", @"focus",
+        ];
+
+        for (size_t t = 0; t < sizeof(targets)/sizeof(targets[0]); t++) {
+            for (NSString *g in greps) {
+                dumpClass(targets[t], g);
+            }
+        }
+
+        // Also dump all classes whose name contains any interesting keyword.
+        listAllAppKitClasses(@"Help");
+        listAllAppKitClasses(@"Search");
+    }
+    return 0;
+}

--- a/docs/search-bar-research.md
+++ b/docs/search-bar-research.md
@@ -1,0 +1,159 @@
+# In-menu search bar — design notes & investigation log
+
+The `menuet.Search` MenuItem type renders an `NSSearchField` inside an
+`NSMenu` (à la Apple's Help search). Getting that to feel right —
+visible text cursor, live filtering, arrow-key navigation of results,
+Enter to activate, Esc to dismiss, remembered query across opens — was
+substantially harder than it sounds because `NSMenu`'s tracking loop is
+walled off from the standard `NSResponder` chain in a way Apple never
+exposed publicly. This document captures what we learned so the next
+person to touch this (probably future-Casey) doesn't have to re-derive
+it from scratch.
+
+## tl;dr — what actually works
+
+- **Text cursor & focus** require flipping a private flag on the popup
+  window via `-[NSPopupMenuWindow setKeyOverride:YES]` plus invoking
+  `-[NSCell selectWithFrame:inView:editor:delegate:start:length:]` on
+  the field's cell to engage a non-modal editing session.
+- **Arrow-key navigation** of the result items requires NSMenu's
+  tracking loop to consider the search field item "actively selected,"
+  and the only way to drive that from outside AppKit is to **synthesize
+  a hardware-level click** on the field via `CGEventPost` —
+  specifically:
+  - `kCGSessionEventTap` (the same level a physical click enters)
+  - the cursor's **live screen position** must be inside the field's
+    rect, because NSMenu validates the click against `CGEventGetLocation`
+    rather than the event's own `.location` field
+  - the click has to happen during the initial tracking-setup window
+    (~tens of ms after `viewDidMoveToWindow` fires non-nil), not on
+    first keystroke or anything user-driven later — NSMenu only accepts
+    the engagement at tracking start
+  - the cursor has to **stay** in the field's rect for the menu's
+    lifetime; NSMenu revokes the active state the moment the cursor
+    leaves
+- The visible mouse-cursor jump that all of this implies is suppressed
+  with `[NSCursor setHiddenUntilMouseMoves:YES]` called **after** the
+  warp (called before, the warp counts as movement and reinstates the
+  cursor immediately).
+- Query persistence across opens is via
+  `NSMenuDidEndTrackingNotification` (snapshot field value); the saved
+  value is reinstated by `populate:` when the menu reopens and the cell
+  is selected with a full range so the next keystroke replaces it.
+
+## Mac App Store implications
+
+`setKeyOverride:` is private API. Apps that use `menuet.Search` will be
+rejected by Mac App Store review. The Go-side doc comment on `Search`
+calls this out explicitly. Direct-distribution apps (the menuet
+ecosystem so far — whyawake, notafan, traytter, etc.) are unaffected.
+
+## What didn't work
+
+Each of these was tried during the investigation. Listed so we don't
+re-tread the same ground.
+
+### Suppressing the visible cursor jump
+
+| Attempt | Result |
+| --- | --- |
+| `[NSCursor hide]` before warp | Apple's docs say `hide` is reinstated on next mouse movement; `CGWarpMouseCursorPosition` counts as movement, so the hide gets undone immediately. Confirmed. |
+| `CGDisplayHideCursor(kCGDirectMainDisplay)` | Bypassed by AppKit's own cursor management during menu tracking — cursor stays visible regardless. |
+| `CGDisplayHideCursor` on every display | Same as above. |
+| Restoring the cursor mid-tracking (after click registered) | NSMenu sees the cursor leave the field and revokes the "field actively selected" state — arrow nav breaks. |
+| `CGAssociateMouseAndMouseCursorPosition(false)` to freeze the visible cursor while warping the logical one | Started down this path but `setHiddenUntilMouseMoves:` after warp made it unnecessary; not fully tested. |
+| Synthetic `mouseDown` via `[NSApp postEvent:]` | NSMenu's tracking loop reinterprets the queued event as a "click outside menu" and dismisses. |
+| Synthetic `mouseDown` via `[NSApp sendEvent:]` | The synchronous dispatch enters AppKit's modal mouse-tracking loop and **blocks for 5+ seconds** waiting for a natural mouse-up that never arrives. |
+| Skip the warp entirely; post `CGEventPost` with the event's `.location` set to the field | Works only when the cursor happens to already be inside the field rect (sometimes true on first open, never reliable). Confirmed via diagnostic distance logging. |
+| Trigger the click on first keystroke (`controlTextDidChange:`) instead of on menu open | Click is absorbed silently; NSMenu's "field active" state is only settable during initial tracking-setup, not mid-session. |
+| Trigger the click in `control:textShouldBeginEditing:` | Same — by the time editing begins, tracking is settled; click does not promote the field. |
+| `accessibilityPerformPress` on the field | NSSearchField advertises zero AX actions including `AXPress`. Not on the table. |
+
+### Other failed angles
+
+| Attempt | Result |
+| --- | --- |
+| Override `_allowsActiveInputContextDuringMenuTracking` via `method_setImplementation` swizzle | Swizzle installs cleanly but AppKit never queries the method. Despite the suggestive name, it's not the gate. |
+| Swizzle `_handleKeyEvent:` on `NSPopupMenuWindow` to capture arrow keys | Swizzle fires for **letter** keys (a, c, Tab, etc.) but **not** for arrow keys (keyCodes 125/126). Arrows are intercepted by NSMenu's tracking event loop at a layer below Obj-C method dispatch — almost certainly plain C functions inside libAppKit that aren't on any class's method table. |
+| `NSEvent.addLocalMonitorForEventsMatchingMask:` for keyDown events | Doesn't fire during NSMenu tracking. Even with `isKey=YES` forced via `setKeyOverride:`. |
+| `[window makeKeyWindow]` to coax the popup window into a state where standard event routing works | No-op. NSPopupMenuWindow overrides `makeKeyWindow` to deny the request during tracking. |
+| `accessibilityPerformPress` on the field | Already mentioned — field advertises no AX actions. |
+
+### `objc_runtime` probe
+
+We dumped every method on `NSMenu`, `NSMenuItem`, `NSPopupMenuWindow`,
+`NSCarbonMenuImpl`, and related classes matching `search` / `filter` /
+`highlight` / `track` / `key` / `first` / `focus`. The probe code is at
+`docs/research/nsmenu_probe.m` (kept for future investigations). It is
+how `setKeyOverride:` and `_handleKeyEvent:` were discovered.
+
+## Why arrow handling is fundamentally inaccessible
+
+`_handleKeyEvent:` is the AppKit private method that handles letter
+keys during menu tracking — we swizzled it and proved it fires for
+letters. But the same swizzle never sees keyCodes 125/126 (Down/Up).
+That tells us arrow keys are processed **before** Obj-C method dispatch
+gets involved — they're handled by static C functions inside libAppKit
+that NSMenu's tracking loop calls directly from its `CGEvent`-pulling
+inner loop. Those functions aren't registered with the Obj-C runtime
+and don't show up in any class dump.
+
+Apple's own Help search works because Apple is **inside** AppKit — they
+can call the private NSMenu-internal C functions (like the
+`_selectNextItem:` family) directly. We can't from outside the
+framework.
+
+The synthetic-click workaround sidesteps this by making NSMenu's
+tracking loop *think the user selected the field item*, after which
+NSMenu's own arrow-key handling routes them at the field's editor
+instead of at result-item navigation. We're hijacking the right state
+machine, just from a different entry point.
+
+## Why the click has to be on menu open, not on first keystroke
+
+The intuition is "trigger the cursor jump only when the user actually
+types, so people who don't search never see the jump." This *does not
+work* — confirmed empirically. The click event is silently absorbed
+when fired any time after tracking has settled. The "field is the
+active menu item" state appears to be set once during NSMenu's tracking
+setup and can only be promoted/demoted via cursor-driven hover events
+or programmatic input *within* the framework. So we have to do the
+click on `viewDidMoveToWindow`'s non-nil call, with the trade-off that
+the cursor briefly jumps even for users who never touch the search.
+
+## Future avenues (untried)
+
+1. **Disassemble libAppKit** with Hopper / lldb to find the actual C
+   function that handles arrow keys during menu tracking. If we find
+   it and can locate the entry point via runtime symbol lookup, calling
+   it directly would replace the click-sim hack. High effort, brittle
+   across OS versions.
+2. **Reverse-engineer Apple's Help menu** specifically. Their search
+   field clearly uses private API we couldn't surface via runtime
+   introspection. Inspecting the actual implementation via lldb on a
+   running TextEdit or similar might reveal the entry point.
+3. **`CGAssociateMouseAndMouseCursorPosition(false)` + `CGWarp`**.
+   Decouples visible cursor from logical cursor — the warp would move
+   the logical position (which NSMenu uses for hit-testing) without
+   the visible cursor moving. We started this path but the
+   `setHiddenUntilMouseMoves:` solution arrived first and made it
+   unnecessary. Worth revisiting if the current behavior ever breaks.
+
+## Files involved
+
+- `menuet.m` — `MenuetSearchView` class (the bulk of the implementation)
+- `menuet.go` — `searchResults` cgo export and `Application.searchResults`
+- `menuitem.go` — `Search` concrete type implementing `MenuItem`
+- `cmd/catalog/catalog.go` — demo of `menuet.Search` over US states
+- `docs/research/nsmenu_probe.m` — runtime introspection tool used to
+  discover private selectors
+
+## macOS version sensitivity
+
+All behaviors documented above were observed on macOS Sequoia (15.x —
+build label "Darwin 24.6.0"). NSMenu's tracking loop has been broadly
+stable since the early Carbon-to-Cocoa transition, but the specific
+private selectors (`setKeyOverride:`, `_handleKeyEvent:`) and the
+mechanics around `setHiddenUntilMouseMoves:` could change. If the
+feature breaks in a future macOS, this document and the probe code at
+`docs/research/nsmenu_probe.m` are the starting point.

--- a/menuet.go
+++ b/menuet.go
@@ -191,6 +191,22 @@ func children(uniqueCString *C.char) *C.char {
 	return C.CString(string(b))
 }
 
+//export searchResults
+func searchResults(searchUniqueCString *C.char, queryCString *C.char) *C.char {
+	unique := C.GoString(searchUniqueCString)
+	query := C.GoString(queryCString)
+	items := App().searchResults(unique, query)
+	if items == nil {
+		return nil
+	}
+	b, err := json.Marshal(items)
+	if err != nil {
+		log.Printf("Marshal: %v", err)
+		return nil
+	}
+	return C.CString(string(b))
+}
+
 //export menuClosed
 func menuClosed(uniqueCString *C.char) {
 	unique := C.GoString(uniqueCString)

--- a/menuet.m
+++ b/menuet.m
@@ -7,6 +7,7 @@
 void itemClicked(const char *);
 void notificationRespond(const char *, const char *);
 const char *children(const char *);
+const char *searchResults(const char *, const char *);
 void menuClosed(const char *);
 bool hideStartup();
 char *startAtLoginLabel();
@@ -18,10 +19,28 @@ void initNotifications(void);
 bool hasTopLevelClicked();
 void topLevelClicked();
 
+// Tag applied to dynamically-inserted search result NSMenuItems. populate:
+// clears items with this tag before rebuilding so a menu refresh doesn't
+// confuse search results with user-supplied items.
+#define MENUET_SEARCH_RESULT_TAG 31337
+
 @class MenuetMenu;
 
 NSStatusItem *_statusItem;
 MenuetMenu *_rootMenu;
+
+@interface MenuetSearchView : NSView <NSSearchFieldDelegate>
+@property(nonatomic, strong) NSSearchField *field;
+@property(nonatomic, copy) NSString *searchUnique;
+@property(nonatomic, copy) NSString *savedQuery;
+@property(nonatomic, assign) NSMenu *trackingMenu;
+@property(nonatomic, assign) CGPoint cursorBeforeWarp;
+@property(nonatomic, assign) BOOL cursorWasWarped;
+- (instancetype)initWithPlaceholder:(NSString *)placeholder
+                        searchUnique:(NSString *)searchUnique;
+- (void)updatePlaceholder:(NSString *)placeholder searchUnique:(NSString *)unique;
+- (void)applyQuery:(NSString *)query;
+@end
 
 @interface MenuetMenu : NSMenu <NSMenuDelegate>
 
@@ -55,6 +74,19 @@ MenuetMenu *_rootMenu;
 }
 
 - (void)populate:(NSArray *)items {
+	// Search-result items are inserted dynamically by MenuetSearchView and
+	// aren't part of the user's children() output. Pull them out first so
+	// the index-keyed reuse below doesn't confuse them with user items.
+	NSMutableArray<NSMenuItem *> *staleResults = [NSMutableArray new];
+	for (NSMenuItem *existing in self.itemArray) {
+		if (existing.tag == MENUET_SEARCH_RESULT_TAG) {
+			[staleResults addObject:existing];
+		}
+	}
+	for (NSMenuItem *r in staleResults) {
+		[self removeItem:r];
+	}
+
 	for (int i = 0; i < items.count; i++) {
 		NSMenuItem *item = nil;
 		if (i < self.numberOfItems) {
@@ -66,6 +98,27 @@ MenuetMenu *_rootMenu;
 			if (!item || !item.isSeparatorItem) {
 				[self insertItem:[NSMenuItem separatorItem] atIndex:i];
 			}
+			continue;
+		}
+		if ([type isEqualTo:@"search"]) {
+			NSString *placeholder = dict[@"Text"] ?: @"";
+			NSString *searchUnique = dict[@"Unique"] ?: @"";
+			BOOL reuse = item && [item.view isKindOfClass:NSClassFromString(@"MenuetSearchView")];
+			if (!reuse) {
+				if (item) [self removeItemAtIndex:i];
+				item = [self insertItemWithTitle:@"" action:nil keyEquivalent:@"" atIndex:i];
+				MenuetSearchView *searchView = [[MenuetSearchView alloc]
+				                initWithPlaceholder:placeholder
+				                       searchUnique:searchUnique];
+				item.view = searchView;
+			} else {
+				MenuetSearchView *searchView = (MenuetSearchView *)item.view;
+				[searchView updatePlaceholder:placeholder searchUnique:searchUnique];
+			}
+			// Defer the actual applyQuery to AFTER the while-loop trim
+			// below — otherwise the trim wipes any results we'd insert
+			// here (items.count == 1 for "[Search]"; the loop would trim
+			// every search result back out).
 			continue;
 		}
 		NSString *unique = dict[@"Unique"];
@@ -118,6 +171,17 @@ MenuetMenu *_rootMenu;
 	}
 	while (self.numberOfItems > items.count) {
 		[self removeItemAtIndex:self.numberOfItems - 1];
+	}
+
+	// Search results live OUTSIDE the user's items array — they're driven
+	// dynamically by the field's query. Apply each search view's saved (or
+	// empty) query here, after the trim, so the inserted results survive.
+	for (NSMenuItem *it in [self.itemArray copy]) {
+		if ([it.view isKindOfClass:NSClassFromString(@"MenuetSearchView")]) {
+			MenuetSearchView *sv = (MenuetSearchView *)it.view;
+			sv.field.stringValue = sv.savedQuery ?: @"";
+			[sv applyQuery:sv.field.stringValue];
+		}
 	}
 }
 
@@ -196,6 +260,297 @@ MenuetMenu *_rootMenu;
 - (void)prepareShutdown:(id)sender {
 	shutdownWait();
 	[NSApp terminate: nil];
+}
+
+@end
+
+// MenuetSearchView hosts an NSSearchField inside an NSMenuItem.
+//
+// AppKit's menu subsystem runs its own event-tracking loop that swallows
+// keystrokes before NSResponder routing has a chance to deliver them to
+// any embedded NSTextField. The accepted workaround (since 2017) is to
+// install a Carbon event handler on the application's event dispatcher:
+// keystrokes still flow through Carbon, even inside menu tracking, so
+// we can intercept them and write into the NSSearchField ourselves.
+//
+// Carbon UI APIs are deprecated, but the Carbon Event Manager subset we
+// use here (InstallEventHandler, GetEventDispatcherTarget, EventRef ->
+// NSEvent via +eventWithEventRef:) is what AppKit itself relies on for
+// NSMenu and remains unmarked-deprecated.
+//
+// Approach and key-passthrough list adapted from
+// Interface declared up at top of file so MenuetMenu's populate: can
+// touch it during menuWillOpen.
+
+@implementation MenuetSearchView
+
+- (instancetype)initWithPlaceholder:(NSString *)placeholder
+                        searchUnique:(NSString *)searchUnique {
+	self = [super initWithFrame:NSMakeRect(0, 0, 240, 28)];
+	if (self) {
+		_searchUnique = [searchUnique copy];
+		_savedQuery = @"";
+		_field = [[NSSearchField alloc] initWithFrame:NSMakeRect(6, 2, 228, 24)];
+		_field.placeholderString = placeholder;
+		_field.delegate = self;
+		_field.autoresizingMask = NSViewWidthSizable;
+		[self addSubview:_field];
+	}
+	return self;
+}
+
+- (void)updatePlaceholder:(NSString *)placeholder searchUnique:(NSString *)unique {
+	if (![self.field.placeholderString isEqualToString:placeholder]) {
+		self.field.placeholderString = placeholder;
+	}
+	// searchUnique changes every menu open (fresh uuid). Don't clobber the
+	// field — savedQuery is what should persist.
+	self.searchUnique = [unique copy];
+}
+
+- (void)dealloc {
+	if (_trackingMenu) {
+		[[NSNotificationCenter defaultCenter] removeObserver:self];
+		_trackingMenu = nil;
+	}
+	[_field release];
+	[_searchUnique release];
+	[_savedQuery release];
+	[super dealloc];
+}
+
+- (void)viewDidMoveToWindow {
+	[super viewDidMoveToWindow];
+	if (self.window == nil) {
+		return;
+	}
+
+	// Subscribe once to end-tracking so we can persist the field's text
+	// across menu opens. The notification is posted by the *root* menu
+	// (not individual submenus), so we don't filter by object.
+	if (!self.trackingMenu) {
+		self.trackingMenu = self.enclosingMenuItem.menu;
+		[[NSNotificationCenter defaultCenter]
+		    addObserver:self
+		       selector:@selector(menuDidEndTracking:)
+		           name:NSMenuDidEndTrackingNotification
+		         object:nil];
+	}
+
+	[self.window makeFirstResponder:self.field];
+
+	// NSPopupMenuWindow refuses regular makeKeyWindow during menu tracking,
+	// so the text field's input context never engages — no cursor blink,
+	// no edit state. Calling the window's private -setKeyOverride:YES
+	// flips its key-state override and lets the field's editor become
+	// active. This is the first of two private hooks the Search type
+	// relies on; documented as an App Store-incompatible caveat.
+	SEL setKeyOverride = NSSelectorFromString(@"setKeyOverride:");
+	if ([self.window respondsToSelector:setKeyOverride]) {
+		NSMethodSignature *sig = [self.window methodSignatureForSelector:setKeyOverride];
+		NSInvocation *inv = [NSInvocation invocationWithMethodSignature:sig];
+		inv.selector = setKeyOverride;
+		BOOL yes = YES;
+		[inv setArgument:&yes atIndex:2];
+		[inv invokeWithTarget:self.window];
+	}
+
+	// Begin an editing session on the field via -selectWithFrame:...
+	// (the non-modal partner of -editWithFrame:...:event:, which spins a
+	// modal event loop and freezes the menu). This gives us a visible text
+	// cursor immediately, plus a selected range so any remembered query
+	// is replaced when the user starts typing.
+	NSText *editor = [self.window fieldEditor:YES forObject:self.field];
+	NSUInteger len = self.field.stringValue.length;
+	[self.field.cell selectWithFrame:self.field.bounds
+	                         inView:self.field
+	                         editor:editor
+	                       delegate:self.field
+	                          start:0
+	                         length:len];
+
+	// Engage NSMenu's "this menu item is actively selected" state for the
+	// search field by synthesizing a hardware-level click on it. Arrow-key
+	// navigation through the result items depends on this state; without
+	// the click, NSMenu's tracking loop reads arrows as menu-nav.
+	//
+	// Constraints we have to thread:
+	//   - NSMenu only accepts this engagement during the initial tracking-
+	//     setup window, so we click on menu open, not on first keystroke.
+	//   - It validates the click against the cursor's LIVE position, so
+	//     the cursor must be inside the field's rect. We pin x to the
+	//     field's left edge (closest to where the parent menu's hover sat)
+	//     to minimize the visible motion.
+	//   - The 150ms delay gives the submenu's window time to finish
+	//     positioning; if we race the layout, the field's screen rect
+	//     comes back garbage and we'd fling the cursor off-screen.
+	//   - The cursor stays at the field for the menu's entire lifetime —
+	//     NSMenu would revoke the active state the moment it leaves. We
+	//     restore the cursor's original position in -menuDidEndTracking:.
+	//   - We hide the cursor via -setHiddenUntilMouseMoves: AFTER the warp.
+	//     Called before, the warp itself counts as movement and immediately
+	//     reinstates the cursor; after, it stays hidden until the user
+	//     physically moves the mouse.
+	dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 150 * NSEC_PER_MSEC),
+	               dispatch_get_main_queue(), ^{
+		if (!self.window) return;
+		NSRect fieldRectInWindow = [self.field convertRect:self.field.bounds
+		                                            toView:nil];
+		NSRect fieldRectOnScreen = [self.window convertRectToScreen:fieldRectInWindow];
+		CGFloat maxY = 0;
+		for (NSScreen *s in NSScreen.screens) {
+			CGFloat top = NSMaxY(s.frame);
+			if (top > maxY) maxY = top;
+		}
+		const CGFloat inset = 4;
+		CGFloat minX = fieldRectOnScreen.origin.x + inset;
+		CGFloat cgMinY = maxY - NSMaxY(fieldRectOnScreen) + inset;
+		CGFloat cgMaxY = maxY - fieldRectOnScreen.origin.y - inset;
+
+		CGEventRef probe = CGEventCreate(NULL);
+		CGPoint orig = CGEventGetLocation(probe);
+		CFRelease(probe);
+
+		CGPoint target = orig;
+		target.x = minX;
+		if (target.y < cgMinY) target.y = cgMinY;
+		if (target.y > cgMaxY) target.y = cgMaxY;
+
+		// If the computed target is off-screen, the submenu's window had
+		// not finished positioning. Bail rather than fling the cursor.
+		// Arrow nav won't work for this particular open.
+		if (target.y < 0 || target.y > maxY || target.x < 0) {
+			return;
+		}
+
+		BOOL needsWarp = (target.x != orig.x) || (target.y != orig.y);
+		self.cursorBeforeWarp = orig;
+		self.cursorWasWarped = needsWarp;
+
+		if (needsWarp) {
+			CGWarpMouseCursorPosition(target);
+			[NSCursor setHiddenUntilMouseMoves:YES];
+		}
+		CGEventRef down = CGEventCreateMouseEvent(NULL, kCGEventLeftMouseDown,
+		                                          target, kCGMouseButtonLeft);
+		CGEventPost(kCGSessionEventTap, down);
+		CFRelease(down);
+		CGEventRef up = CGEventCreateMouseEvent(NULL, kCGEventLeftMouseUp,
+		                                        target, kCGMouseButtonLeft);
+		CGEventPost(kCGSessionEventTap, up);
+		CFRelease(up);
+	});
+}
+
+- (void)menuDidEndTracking:(NSNotification *)note {
+	self.savedQuery = self.field.stringValue;
+	if (self.cursorWasWarped) {
+		CGWarpMouseCursorPosition(self.cursorBeforeWarp);
+		self.cursorWasWarped = NO;
+	}
+}
+
+// NSTextFieldDelegate: live filtering as the user types.
+- (void)controlTextDidChange:(NSNotification *)note {
+	[self applyQuery:self.field.stringValue];
+}
+
+// NSTextFieldDelegate: intercept specific keys so Enter activates the first
+// result, Esc closes the menu, and Down hands focus back to NSMenu so its
+// arrow-key navigation can walk the result items.
+- (BOOL)control:(NSControl *)control
+       textView:(NSTextView *)textView
+doCommandBySelector:(SEL)cmd {
+	NSMenu *menu = self.enclosingMenuItem.menu;
+	if (cmd == @selector(insertNewline:)) {
+		NSMenuItem *first = [self firstActionableResult];
+		if (first) {
+			[NSApp sendAction:first.action to:first.target from:first];
+			[menu cancelTracking];
+		}
+		return YES;
+	}
+	if (cmd == @selector(cancelOperation:)) {
+		[menu cancelTracking];
+		return YES;
+	}
+	if (cmd == @selector(moveDown:)) {
+		// Relinquish first responder so NSMenu's own tracking handles arrows.
+		[self.window makeFirstResponder:self.window];
+		return YES;
+	}
+	return NO;
+}
+
+- (void)applyQuery:(NSString *)query {
+	const char *json = searchResults(self.searchUnique.UTF8String, query.UTF8String);
+	NSArray *items = @[];
+	if (json != NULL) {
+		NSData *data = [[NSString stringWithUTF8String:json]
+		                dataUsingEncoding:NSUTF8StringEncoding];
+		items = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil] ?: @[];
+		free((char *)json);
+	}
+
+	NSMenuItem *enclosing = self.enclosingMenuItem;
+	NSMenu *menu = enclosing.menu;
+	if (!menu) {
+		return;
+	}
+
+	// The menu's tag is the source of truth for what's a search result.
+	// AppKit cycles view-window state multiple times per open, and
+	// populate: can also pull tagged items out from under us — re-deriving
+	// from menu.itemArray each time absorbs all of that without modeling
+	// AppKit's internals.
+	NSMutableArray<NSMenuItem *> *stale = [NSMutableArray new];
+	for (NSMenuItem *existing in menu.itemArray) {
+		if (existing.tag == MENUET_SEARCH_RESULT_TAG) {
+			[stale addObject:existing];
+		}
+	}
+	for (NSMenuItem *r in stale) {
+		[menu removeItem:r];
+	}
+
+	// Insert fresh items below the search field.
+	NSInteger insertIndex = [menu indexOfItem:enclosing] + 1;
+	for (NSDictionary *dict in items) {
+		NSString *type = dict[@"Type"];
+		NSMenuItem *newItem;
+		if ([type isEqual:@"separator"]) {
+			newItem = [NSMenuItem separatorItem];
+		} else {
+			NSString *text = dict[@"Text"] ?: @"";
+			BOOL clickable = [dict[@"Clickable"] boolValue];
+			newItem = [[NSMenuItem alloc] initWithTitle:text action:nil keyEquivalent:@""];
+			if (clickable) {
+				newItem.target = menu;
+				newItem.action = @selector(press:);
+				newItem.representedObject = dict[@"Unique"];
+			}
+		}
+		newItem.tag = MENUET_SEARCH_RESULT_TAG;
+		[menu insertItem:newItem atIndex:insertIndex];
+		insertIndex++;
+	}
+
+	// Force NSMenu to recompute its layout. Without this, items inserted
+	// during tracking can render but the menu doesn't grow — the new rows
+	// end up outside the visible content rect.
+	[menu update];
+}
+
+// Returns the first tagged search-result item in this view's menu that has
+// an action — used by the Enter key handler.
+- (NSMenuItem *)firstActionableResult {
+	NSMenu *menu = self.enclosingMenuItem.menu;
+	for (NSMenuItem *it in menu.itemArray) {
+		if (it.tag == MENUET_SEARCH_RESULT_TAG && it.action != NULL) {
+			return it;
+		}
+	}
+	return nil;
 }
 
 @end
@@ -294,8 +649,16 @@ void createAndRunApplication() {
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center
        willPresentNotification:(UNNotification *)notification
        withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler {
-        completionHandler(UNNotificationPresentationOptionBanner |
-                          UNNotificationPresentationOptionSound);
+        if (@available(macOS 11.0, *)) {
+                completionHandler(UNNotificationPresentationOptionBanner |
+                                  UNNotificationPresentationOptionSound);
+        } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+                completionHandler(UNNotificationPresentationOptionAlert |
+                                  UNNotificationPresentationOptionSound);
+#pragma clang diagnostic pop
+        }
 }
 
 @end

--- a/menuitem.go
+++ b/menuitem.go
@@ -35,6 +35,23 @@ type Separator struct{}
 
 func (Separator) menuItem() {}
 
+// Search is an in-menu search field. The Results callback fires on every
+// keystroke with the current query (empty string when the menu first
+// opens). Returned items appear immediately below the search field and
+// replace whatever was there before.
+//
+// Apps that use Search cannot be distributed via the Mac App Store: the
+// underlying keystroke-capture relies on the Carbon Event Manager, and
+// the as-you-type highlight uses [NSMenu highlightItem:], a private
+// AppKit selector. Both are stable on current macOS, but private API
+// triggers Mac App Store rejection.
+type Search struct {
+	Placeholder string
+	Results     func(query string) []MenuItem
+}
+
+func (Search) menuItem() {}
+
 type internalItem struct {
 	Unique       string
 	ParentUnique string
@@ -69,6 +86,10 @@ func buildInternalItem(item MenuItem, unique, parentUnique string) internalItem 
 		out.HasChildren = v.Children != nil
 	case Separator:
 		out.Type = "separator"
+	case Search:
+		out.Type = "search"
+		// Text doubles as the placeholder string on the ObjC side.
+		out.Text = v.Placeholder
 	}
 	return out
 }
@@ -99,6 +120,49 @@ func (a *Application) children(unique string) []internalItem {
 	for ind, item := range items {
 		newUnique := askm.ArbitraryKeyNotInMap(a.visibleMenuItems)
 		internal := buildInternalItem(item, newUnique, unique)
+		a.visibleMenuItems[newUnique] = internal
+		internalItems[ind] = internal
+	}
+	return internalItems
+}
+
+// searchResults runs the Search.Results callback for the search item with
+// the given unique ID, replacing any previously-registered result items
+// for this search and returning the fresh items to the ObjC side. Called
+// on every keystroke and once with an empty query when the search field
+// is first rendered.
+func (a *Application) searchResults(searchUnique, query string) []internalItem {
+	a.visibleMenuItemsMutex.RLock()
+	item, ok := a.visibleMenuItems[searchUnique]
+	a.visibleMenuItemsMutex.RUnlock()
+	if !ok {
+		log.Printf("Search item not found: %s", searchUnique)
+		return nil
+	}
+	search, ok := item.item.(Search)
+	if !ok {
+		log.Printf("Item %s is not a Search: %T", searchUnique, item.item)
+		return nil
+	}
+	if search.Results == nil {
+		return nil
+	}
+
+	items := search.Results(query)
+
+	a.visibleMenuItemsMutex.Lock()
+	defer a.visibleMenuItemsMutex.Unlock()
+	// Drop result items from the previous query — they were registered
+	// with ParentUnique == searchUnique by an earlier call.
+	for k, v := range a.visibleMenuItems {
+		if v.ParentUnique == searchUnique {
+			delete(a.visibleMenuItems, k)
+		}
+	}
+	internalItems := make([]internalItem, len(items))
+	for ind, child := range items {
+		newUnique := askm.ArbitraryKeyNotInMap(a.visibleMenuItems)
+		internal := buildInternalItem(child, newUnique, searchUnique)
 		a.visibleMenuItems[newUnique] = internal
 		internalItems[ind] = internal
 	}

--- a/search_test.go
+++ b/search_test.go
@@ -1,0 +1,199 @@
+package menuet
+
+import (
+	"encoding/json"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestBuildInternalItemSearchSerialization(t *testing.T) {
+	// Search uses Text as the placeholder on the ObjC side; Type must be
+	// "search" so menuet.m's populate: dispatches to the search-view path.
+	item := buildInternalItem(
+		Search{Placeholder: "Search apps…", Results: func(string) []MenuItem { return nil }},
+		"unique-1", "parent-1",
+	)
+	if item.Type != "search" {
+		t.Errorf("Type = %q, want %q", item.Type, "search")
+	}
+	if item.Text != "Search apps…" {
+		t.Errorf("Text = %q, want placeholder copied from Search.Placeholder", item.Text)
+	}
+
+	b, err := json.Marshal(item)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	got := string(b)
+	for _, want := range []string{
+		`"Type":"search"`,
+		`"Text":"Search apps…"`,
+		`"Unique":"unique-1"`,
+		`"ParentUnique":"parent-1"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("JSON missing %q\nfull: %s", want, got)
+		}
+	}
+}
+
+func TestApplicationSearchResultsRunsCallbackWithQuery(t *testing.T) {
+	a := App()
+	defer func() {
+		a.visibleMenuItemsMutex.Lock()
+		a.visibleMenuItems = make(map[string]internalItem)
+		a.visibleMenuItemsMutex.Unlock()
+	}()
+
+	var received atomic.Value
+	received.Store("")
+	resultsFn := func(q string) []MenuItem {
+		received.Store(q)
+		return []MenuItem{Regular{Text: "Result for " + q}}
+	}
+
+	const searchUnique = "search-1"
+	a.visibleMenuItemsMutex.Lock()
+	a.visibleMenuItems[searchUnique] = internalItem{
+		Unique: searchUnique,
+		Type:   "search",
+		item:   Search{Placeholder: "go", Results: resultsFn},
+	}
+	a.visibleMenuItemsMutex.Unlock()
+
+	got := a.searchResults(searchUnique, "hello")
+	if received.Load().(string) != "hello" {
+		t.Errorf("Search.Results received %q, want %q", received.Load(), "hello")
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d items, want 1", len(got))
+	}
+	if got[0].Text != "Result for hello" {
+		t.Errorf("Text = %q, want %q", got[0].Text, "Result for hello")
+	}
+	if got[0].ParentUnique != searchUnique {
+		t.Errorf("ParentUnique = %q, want %q", got[0].ParentUnique, searchUnique)
+	}
+}
+
+func TestApplicationSearchResultsCleansUpPriorResults(t *testing.T) {
+	// Each keystroke replaces the prior result items. Previously registered
+	// results (with ParentUnique == searchUnique) must be removed from
+	// visibleMenuItems so the map doesn't grow unbounded.
+	a := App()
+	defer func() {
+		a.visibleMenuItemsMutex.Lock()
+		a.visibleMenuItems = make(map[string]internalItem)
+		a.visibleMenuItemsMutex.Unlock()
+	}()
+
+	const searchUnique = "search-2"
+	a.visibleMenuItemsMutex.Lock()
+	a.visibleMenuItems[searchUnique] = internalItem{
+		Unique: searchUnique,
+		Type:   "search",
+		item: Search{Results: func(q string) []MenuItem {
+			return []MenuItem{Regular{Text: "first"}, Regular{Text: "second"}}
+		}},
+	}
+	a.visibleMenuItemsMutex.Unlock()
+
+	a.searchResults(searchUnique, "q1")
+	// Count how many items have this search as their parent.
+	count := func() int {
+		a.visibleMenuItemsMutex.RLock()
+		defer a.visibleMenuItemsMutex.RUnlock()
+		n := 0
+		for _, v := range a.visibleMenuItems {
+			if v.ParentUnique == searchUnique {
+				n++
+			}
+		}
+		return n
+	}
+	if got := count(); got != 2 {
+		t.Errorf("after first query: %d result items, want 2", got)
+	}
+
+	a.searchResults(searchUnique, "q2")
+	if got := count(); got != 2 {
+		t.Errorf("after second query: %d result items, want 2 (old ones should have been replaced, not appended)", got)
+	}
+}
+
+func TestApplicationSearchResultsMissingItemReturnsNil(t *testing.T) {
+	a := App()
+	if got := a.searchResults("does-not-exist", ""); got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+}
+
+func TestApplicationSearchResultsWrongTypeReturnsNil(t *testing.T) {
+	// If something registered under a unique isn't actually a Search, we
+	// should log and return nil rather than panic on a bad type assertion.
+	a := App()
+	defer func() {
+		a.visibleMenuItemsMutex.Lock()
+		a.visibleMenuItems = make(map[string]internalItem)
+		a.visibleMenuItemsMutex.Unlock()
+	}()
+	a.visibleMenuItemsMutex.Lock()
+	a.visibleMenuItems["regular-1"] = internalItem{
+		Unique: "regular-1",
+		item:   Regular{Text: "not a search"},
+	}
+	a.visibleMenuItemsMutex.Unlock()
+
+	if got := a.searchResults("regular-1", ""); got != nil {
+		t.Errorf("expected nil for non-Search item, got %v", got)
+	}
+}
+
+func TestApplicationSearchResultsNilCallbackReturnsNil(t *testing.T) {
+	a := App()
+	defer func() {
+		a.visibleMenuItemsMutex.Lock()
+		a.visibleMenuItems = make(map[string]internalItem)
+		a.visibleMenuItemsMutex.Unlock()
+	}()
+	a.visibleMenuItemsMutex.Lock()
+	a.visibleMenuItems["search-3"] = internalItem{
+		Unique: "search-3",
+		item:   Search{Placeholder: "x"}, // no Results
+	}
+	a.visibleMenuItemsMutex.Unlock()
+
+	if got := a.searchResults("search-3", "anything"); got != nil {
+		t.Errorf("expected nil when Search.Results is nil, got %v", got)
+	}
+}
+
+func TestApplicationSearchResultsConcurrentCallsDontDeadlock(t *testing.T) {
+	// searchResults takes the write lock when mutating visibleMenuItems.
+	// Make sure rapid keystrokes from the ObjC side don't deadlock against
+	// concurrent children() lookups.
+	a := App()
+	defer func() {
+		a.visibleMenuItemsMutex.Lock()
+		a.visibleMenuItems = make(map[string]internalItem)
+		a.visibleMenuItemsMutex.Unlock()
+	}()
+	a.visibleMenuItemsMutex.Lock()
+	a.visibleMenuItems["search-4"] = internalItem{
+		Unique: "search-4",
+		item:   Search{Results: func(q string) []MenuItem { return []MenuItem{Regular{Text: q}} }},
+	}
+	a.visibleMenuItemsMutex.Unlock()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			a.searchResults("search-4", string(rune('a'+i%26)))
+		}(i)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
New concrete \`Search\` type implementing \`MenuItem\` — an Apple-Help-style search field inside an NSMenu.

## API

\`\`\`go
menuet.Search{
    Placeholder: \"Search files…\",
    Results: func(query string) []menuet.MenuItem {
        if query == \"\" { return recentFiles() }
        return matches(query)
    },
}
\`\`\`

\`Results\` runs on every keystroke (and once with \`\"\"\` on menu open). Returned items render below the field and update live. The last query persists across menu opens and is preselected so the next keystroke replaces it.

## What works

  - Live text filtering as the user types
  - Visible text cursor in the field
  - Hover to open submenu (no manual click required)
  - Click a result → fires its \`Clicked\` callback
  - Enter → activates the first result
  - Esc → closes the menu
  - Query remembered across opens

## Known limitation: visible mouse-cursor jump

The mouse cursor briefly jumps to the field's left edge on menu open. This is structural — NSMenu validates the synthetic click against the cursor's *live* position, not the event's location field, so the cursor genuinely has to be inside the field rect for arrow-key navigation to work. We mitigate via:
  - Pinning the warp target to the field's left edge (minimum visual distance)
  - \`[NSCursor setHiddenUntilMouseMoves:YES]\` immediately after the warp (cursor stays hidden until the user physically moves the mouse)
  - Restoring the cursor to its original position when tracking ends

Result: keyboard-only users effectively never see the jump.

The mid-tracking elision bug (long state names like \"Massachusetts\" get center-elided when the menu's content rect doesn't grow to match newly-inserted items) is a separate issue, tracked for a follow-up.

## ⚠ App Store implications

\`Search\` uses two private AppKit hooks (\`setKeyOverride:\` and a synthesized hardware-level click via \`CGEventPost\`). Apps using \`menuet.Search\` cannot be distributed via the Mac App Store. Direct-distribution apps (the existing menuet ecosystem — whyawake, notafan, traytter, etc.) are unaffected. The trade-off is called out in the \`Search\` struct's doc comment.

## Investigation notes

\`docs/search-bar-research.md\` captures the full architectural story: every approach tried, why each failed, what the structural constraints are inside AppKit's menu tracking, and a list of untried avenues for future improvement. \`docs/research/nsmenu_probe.m\` is the runtime introspection tool used to surface the private selectors.

## Tests

7 unit tests in \`search_test.go\` cover the Go-side plumbing — JSON serialization shape, query callback invocation, result-item cleanup across keystrokes, error paths (missing item, wrong type, nil callback), and concurrent invocation safety.

\`go build ./...\`, \`go vet ./...\`, \`go test ./...\` all clean.