### PR TITLE
v2.3.1: Drop cursor warping; fix elision + query persistence

### DIFF
--- a/docs/search-bar-research.md
+++ b/docs/search-bar-research.md
@@ -10,36 +10,37 @@ exposed publicly. This document captures what we learned so the next
 person to touch this (probably future-Casey) doesn't have to re-derive
 it from scratch.
 
-## tl;dr — what actually works
+## tl;dr — what actually shipped
 
 - **Text cursor & focus** require flipping a private flag on the popup
   window via `-[NSPopupMenuWindow setKeyOverride:YES]` plus invoking
   `-[NSCell selectWithFrame:inView:editor:delegate:start:length:]` on
   the field's cell to engage a non-modal editing session.
-- **Arrow-key navigation** of the result items requires NSMenu's
-  tracking loop to consider the search field item "actively selected,"
-  and the only way to drive that from outside AppKit is to **synthesize
-  a hardware-level click** on the field via `CGEventPost` —
-  specifically:
-  - `kCGSessionEventTap` (the same level a physical click enters)
-  - the cursor's **live screen position** must be inside the field's
-    rect, because NSMenu validates the click against `CGEventGetLocation`
-    rather than the event's own `.location` field
-  - the click has to happen during the initial tracking-setup window
-    (~tens of ms after `viewDidMoveToWindow` fires non-nil), not on
-    first keystroke or anything user-driven later — NSMenu only accepts
-    the engagement at tracking start
-  - the cursor has to **stay** in the field's rect for the menu's
-    lifetime; NSMenu revokes the active state the moment the cursor
-    leaves
-- The visible mouse-cursor jump that all of this implies is suppressed
-  with `[NSCursor setHiddenUntilMouseMoves:YES]` called **after** the
-  warp (called before, the warp counts as movement and reinstates the
-  cursor immediately).
-- Query persistence across opens is via
-  `NSMenuDidEndTrackingNotification` (snapshot field value); the saved
-  value is reinstated by `populate:` when the menu reopens and the cell
-  is selected with a full range so the next keystroke replaces it.
+- **Type-to-filter** flows naturally once the field is first responder
+  and the input context is engaged — `controlTextDidChange:` fires on
+  each keystroke and we call back into Go for fresh result items.
+- **Enter activates the first result; Esc closes the menu** — both
+  routed through `-[NSControlTextEditingDelegate control:textView:
+  doCommandBySelector:]`.
+- **Query persistence across opens**: saved in
+  `viewDidMoveToWindow` whenever the SearchView's window goes nil
+  (catches submenu close even when the root menu's tracking continues)
+  and again in `NSMenuDidEndTrackingNotification` as a safety net. The
+  saved value is restored by `populate:` when the menu reopens, with
+  the field's full range selected so the next keystroke replaces it.
+- **Mid-tracking elision** of long result strings is avoided by
+  forcing `NSLineBreakByClipping` in each item's attributed title
+  (bypasses the elide) and growing the menu's `minimumWidth` to
+  whichever item's `NSMenuItemCell.cellSize.width` is widest. The
+  width "ratchets up" within a session and never shrinks (jarring).
+- **Arrow-key navigation** of result items is NOT supported. We
+  determined this requires synthesizing a hardware-level mouse click
+  (`CGEventPost`) on the field to promote it to NSMenu's actively-
+  selected item state. The trade-offs (Accessibility permission
+  prompt, visible mouse cursor warp, fragility under user mouse
+  movement during the menu) were worse than just not supporting
+  arrow nav. The full investigation is preserved in the "What didn't
+  work" section below in case a cleaner approach surfaces later.
 
 ## Mac App Store implications
 
@@ -47,6 +48,8 @@ it from scratch.
 rejected by Mac App Store review. The Go-side doc comment on `Search`
 calls this out explicitly. Direct-distribution apps (the menuet
 ecosystem so far — whyawake, notafan, traytter, etc.) are unaffected.
+We did **not** ship the click-sim arrow-key approach, so no
+`CGEventPost` and no Accessibility permission prompt on first run.
 
 ## What didn't work
 

--- a/menuet.m
+++ b/menuet.m
@@ -34,8 +34,6 @@ MenuetMenu *_rootMenu;
 @property(nonatomic, copy) NSString *searchUnique;
 @property(nonatomic, copy) NSString *savedQuery;
 @property(nonatomic, assign) NSMenu *trackingMenu;
-@property(nonatomic, assign) CGPoint cursorBeforeWarp;
-@property(nonatomic, assign) BOOL cursorWasWarped;
 - (instancetype)initWithPlaceholder:(NSString *)placeholder
                         searchUnique:(NSString *)searchUnique;
 - (void)updatePlaceholder:(NSString *)placeholder searchUnique:(NSString *)unique;
@@ -322,6 +320,13 @@ MenuetMenu *_rootMenu;
 - (void)viewDidMoveToWindow {
 	[super viewDidMoveToWindow];
 	if (self.window == nil) {
+		// Submenu closed (either user moved off to another parent-menu
+		// item or the whole tracking session ended). Snapshot the field
+		// so the query persists across re-opens. Safe to run on AppKit's
+		// open-time view-window cycles too — the field's value at that
+		// point is whatever populate: just set it to (either the prior
+		// savedQuery or "").
+		self.savedQuery = self.field.stringValue;
 		return;
 	}
 
@@ -368,86 +373,10 @@ MenuetMenu *_rootMenu;
 	                       delegate:self.field
 	                          start:0
 	                         length:len];
-
-	// Engage NSMenu's "this menu item is actively selected" state for the
-	// search field by synthesizing a hardware-level click on it. Arrow-key
-	// navigation through the result items depends on this state; without
-	// the click, NSMenu's tracking loop reads arrows as menu-nav.
-	//
-	// Constraints we have to thread:
-	//   - NSMenu only accepts this engagement during the initial tracking-
-	//     setup window, so we click on menu open, not on first keystroke.
-	//   - It validates the click against the cursor's LIVE position, so
-	//     the cursor must be inside the field's rect. We pin x to the
-	//     field's left edge (closest to where the parent menu's hover sat)
-	//     to minimize the visible motion.
-	//   - The 150ms delay gives the submenu's window time to finish
-	//     positioning; if we race the layout, the field's screen rect
-	//     comes back garbage and we'd fling the cursor off-screen.
-	//   - The cursor stays at the field for the menu's entire lifetime —
-	//     NSMenu would revoke the active state the moment it leaves. We
-	//     restore the cursor's original position in -menuDidEndTracking:.
-	//   - We hide the cursor via -setHiddenUntilMouseMoves: AFTER the warp.
-	//     Called before, the warp itself counts as movement and immediately
-	//     reinstates the cursor; after, it stays hidden until the user
-	//     physically moves the mouse.
-	dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 150 * NSEC_PER_MSEC),
-	               dispatch_get_main_queue(), ^{
-		if (!self.window) return;
-		NSRect fieldRectInWindow = [self.field convertRect:self.field.bounds
-		                                            toView:nil];
-		NSRect fieldRectOnScreen = [self.window convertRectToScreen:fieldRectInWindow];
-		CGFloat maxY = 0;
-		for (NSScreen *s in NSScreen.screens) {
-			CGFloat top = NSMaxY(s.frame);
-			if (top > maxY) maxY = top;
-		}
-		const CGFloat inset = 4;
-		CGFloat minX = fieldRectOnScreen.origin.x + inset;
-		CGFloat cgMinY = maxY - NSMaxY(fieldRectOnScreen) + inset;
-		CGFloat cgMaxY = maxY - fieldRectOnScreen.origin.y - inset;
-
-		CGEventRef probe = CGEventCreate(NULL);
-		CGPoint orig = CGEventGetLocation(probe);
-		CFRelease(probe);
-
-		CGPoint target = orig;
-		target.x = minX;
-		if (target.y < cgMinY) target.y = cgMinY;
-		if (target.y > cgMaxY) target.y = cgMaxY;
-
-		// If the computed target is off-screen, the submenu's window had
-		// not finished positioning. Bail rather than fling the cursor.
-		// Arrow nav won't work for this particular open.
-		if (target.y < 0 || target.y > maxY || target.x < 0) {
-			return;
-		}
-
-		BOOL needsWarp = (target.x != orig.x) || (target.y != orig.y);
-		self.cursorBeforeWarp = orig;
-		self.cursorWasWarped = needsWarp;
-
-		if (needsWarp) {
-			CGWarpMouseCursorPosition(target);
-			[NSCursor setHiddenUntilMouseMoves:YES];
-		}
-		CGEventRef down = CGEventCreateMouseEvent(NULL, kCGEventLeftMouseDown,
-		                                          target, kCGMouseButtonLeft);
-		CGEventPost(kCGSessionEventTap, down);
-		CFRelease(down);
-		CGEventRef up = CGEventCreateMouseEvent(NULL, kCGEventLeftMouseUp,
-		                                        target, kCGMouseButtonLeft);
-		CGEventPost(kCGSessionEventTap, up);
-		CFRelease(up);
-	});
 }
 
 - (void)menuDidEndTracking:(NSNotification *)note {
 	self.savedQuery = self.field.stringValue;
-	if (self.cursorWasWarped) {
-		CGWarpMouseCursorPosition(self.cursorBeforeWarp);
-		self.cursorWasWarped = NO;
-	}
 }
 
 // NSTextFieldDelegate: live filtering as the user types.
@@ -455,9 +384,7 @@ MenuetMenu *_rootMenu;
 	[self applyQuery:self.field.stringValue];
 }
 
-// NSTextFieldDelegate: intercept specific keys so Enter activates the first
-// result, Esc closes the menu, and Down hands focus back to NSMenu so its
-// arrow-key navigation can walk the result items.
+// NSTextFieldDelegate: Enter activates the first result; Esc closes the menu.
 - (BOOL)control:(NSControl *)control
        textView:(NSTextView *)textView
 doCommandBySelector:(SEL)cmd {
@@ -472,11 +399,6 @@ doCommandBySelector:(SEL)cmd {
 	}
 	if (cmd == @selector(cancelOperation:)) {
 		[menu cancelTracking];
-		return YES;
-	}
-	if (cmd == @selector(moveDown:)) {
-		// Relinquish first responder so NSMenu's own tracking handles arrows.
-		[self.window makeFirstResponder:self.window];
 		return YES;
 	}
 	return NO;
@@ -524,6 +446,13 @@ doCommandBySelector:(SEL)cmd {
 			NSString *text = dict[@"Text"] ?: @"";
 			BOOL clickable = [dict[@"Clickable"] boolValue];
 			newItem = [[NSMenuItem alloc] initWithTitle:text action:nil keyEquivalent:@""];
+			// Force no truncation at the cell layer — bypasses the cached
+			// "drawable width" elision NSMenu falls back to mid-tracking.
+			NSMutableParagraphStyle *para = [NSMutableParagraphStyle new];
+			para.lineBreakMode = NSLineBreakByClipping;
+			newItem.attributedTitle = [[NSAttributedString alloc]
+			    initWithString:text
+			        attributes:@{NSParagraphStyleAttributeName: para}];
 			if (clickable) {
 				newItem.target = menu;
 				newItem.action = @selector(press:);
@@ -535,10 +464,32 @@ doCommandBySelector:(SEL)cmd {
 		insertIndex++;
 	}
 
-	// Force NSMenu to recompute its layout. Without this, items inserted
-	// during tracking can render but the menu doesn't grow — the new rows
-	// end up outside the visible content rect.
 	[menu update];
+
+	// NSMenu sizes the popup window's content rect once at first display
+	// and doesn't grow it for items inserted mid-tracking, so any result
+	// wider than what was there originally gets clipped at the cached
+	// cell width. Fix: ask the actual NSMenuItemCell for the cell size it
+	// wants for each result item (same code AppKit uses to draw), then
+	// grow the menu's minimumWidth to fit the widest.
+	//
+	// Only grow, never shrink — shrinking mid-tracking is jarring and
+	// AppKit doesn't actually contract the popup window after we shrink
+	// minimumWidth anyway. The width "ratchets up" to fit whatever's
+	// widest in this session.
+	CGFloat widestCell = 0;
+	for (NSMenuItem *it in menu.itemArray) {
+		if (it.tag != MENUET_SEARCH_RESULT_TAG) continue;
+		NSMenuItemCell *cell = [[NSMenuItemCell alloc] init];
+		cell.menuItem = it;
+		CGFloat w = cell.cellSize.width;
+		[cell release];
+		if (w > widestCell) widestCell = w;
+	}
+	CGFloat needed = ceil(widestCell);
+	if (needed > menu.minimumWidth) {
+		menu.minimumWidth = needed;
+	}
 }
 
 // Returns the first tagged search-result item in this view's menu that has

--- a/menuitem.go
+++ b/menuitem.go
@@ -38,13 +38,18 @@ func (Separator) menuItem() {}
 // Search is an in-menu search field. The Results callback fires on every
 // keystroke with the current query (empty string when the menu first
 // opens). Returned items appear immediately below the search field and
-// replace whatever was there before.
+// replace whatever was there before. The last query is remembered across
+// menu opens.
 //
-// Apps that use Search cannot be distributed via the Mac App Store: the
-// underlying keystroke-capture relies on the Carbon Event Manager, and
-// the as-you-type highlight uses [NSMenu highlightItem:], a private
-// AppKit selector. Both are stable on current macOS, but private API
-// triggers Mac App Store rejection.
+// Press Enter to activate the top result, Esc to dismiss, or click any
+// result. Arrow keys do not navigate result items — NSMenu's tracking
+// loop owns them at a layer outside this library's reach.
+//
+// Apps that use Search cannot be distributed via the Mac App Store —
+// the implementation uses a private NSPopupMenuWindow selector
+// (setKeyOverride:) to engage the text field's input context during
+// menu tracking. Stable on current macOS but private-API-rejection
+// material for the App Store. Direct-distribution apps are unaffected.
 type Search struct {
 	Placeholder string
 	Results     func(query string) []MenuItem


### PR DESCRIPTION
Follow-up to v2.3.0.

## Why drop the click sim

The cursor-warp + CGEventPost click that engaged NSMenu's \"field actively selected\" state (the requirement for arrow-key navigation through results) had three real costs:

1. Accessibility-permission prompt on first run (CGEventPost requires it)
2. Visibly jumping mouse cursor for every Search open
3. Fragile under user mouse movement during the menu — moving the cursor revoked the active state and broke arrow nav, and restoring the cursor on close caused a second, more disorienting jump

The arrow-key UX wasn't worth those costs. Dropping the click sim entirely. Everything else stays:

  - Type to filter (live)
  - Enter activates the first result
  - Esc closes the menu
  - Click any result to pick
  - Remembered query across menu opens

Arrow-key navigation is now documented as a non-feature in the \`Search\` doc comment.

## Bug fixes

  - **Mid-tracking elision** of long result strings (\"Mass…usetts\"). Setting \`NSLineBreakByClipping\` on each item's attributed title bypasses the elide; growing \`menu.minimumWidth\` to the widest \`NSMenuItemCell.cellSize.width\` keeps the menu sized correctly. Width ratchets up within a session and never shrinks (which is jarring).
  - **Query not persisting** when the user moused away from the submenu and back. \`NSMenuDidEndTrackingNotification\` only fires when the *root* menu's session ends. Now we also save in \`viewDidMoveToWindow\` when the window goes nil — which fires for submenu close too.

## Docs

\`docs/search-bar-research.md\` updated to reflect the final design; the click-sim investigation is preserved as historical record in case a cleaner approach surfaces later.