### PR TITLE
Document toggle-style app patterns (addresses #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,36 @@ menuet.App().Children = func() []menuet.MenuItem {
 `FontWeight`, `State`, `Clicked`, `Children`. Setting `Clicked` makes it
 clickable; setting `Children` makes it a submenu.
 
+## Toggle-style apps
+
+For apps where the primary action is a toggle (mute audio, pause a
+timer, hide notifications…), macOS menus dismiss the moment the user
+clicks an item — there's no public API to "click without closing." Two
+patterns work around it:
+
+**Left click toggles, right click opens the menu.** Set
+`Application.Clicked` to a callback; left clicks fire the callback
+without opening the menu, right clicks (and Ctrl-left-clicks) still
+open the menu for secondary actions:
+
+```go
+menuet.App().Clicked = func() { toggleMuted() }
+```
+
+**Stateful menu items with checkmarks.** For toggles you do want inside
+the menu, set `MenuItem.State = true` to show a checkmark, and update
+your app state from the `Clicked` callback. The menu will dismiss on
+click as usual (OS standard); on the next open, return the items with
+the new `State`:
+
+```go
+menuet.Regular{
+    Text:    "Notifications enabled",
+    State:   prefs.NotificationsEnabled,
+    Clicked: func() { prefs.NotificationsEnabled = !prefs.NotificationsEnabled },
+}
+```
+
 ## [Catalog](https://github.com/caseymrm/menuet/tree/master/cmd/catalog)
 
 The catalog app is useful for trying many of the possible combinations of features.


### PR DESCRIPTION
Adds a \"Toggle-style apps\" section to the README that ties together the two existing menuet features for apps whose primary user interaction is a toggle:

  - \`Application.Clicked\` (v2.1.0) — left click on the menubar icon fires a callback without opening the menu
  - \`MenuItem.State\` + click callback — in-menu toggles with visible checkmark

The macOS menu system doesn't provide a public way to keep the menu open after a click (it dismisses by design). These two patterns cover the use case the issue was asking about without that limitation.

Addresses #11 (\"Question: Close after Clicked\") from 2019.