### PR TITLE
v2.4.0: RichText — per-item color + monospace + per-run styling

### DIFF
--- a/cmd/catalog/catalog.go
+++ b/cmd/catalog/catalog.go
@@ -124,6 +124,54 @@ func menuItems() []menuet.MenuItem {
 			Text:     "Search",
 			Children: searchDemo,
 		},
+		menuet.Regular{
+			Text:     "Rich text",
+			Children: richTextDemo,
+		},
+	}
+}
+
+func richTextDemo() []menuet.MenuItem {
+	return []menuet.MenuItem{
+		menuet.Regular{
+			Text:  "Item-level color (red)",
+			Color: menuet.Red,
+		},
+		menuet.Regular{
+			Text:       "Monospaced",
+			Monospaced: true,
+		},
+		menuet.Regular{
+			Text:       "Mono + bold",
+			Monospaced: true,
+			FontWeight: menuet.WeightBold,
+		},
+		menuet.Regular{
+			Runs: []menuet.TextRun{
+				{Text: "Status: "},
+				{Text: "FAILED", Color: menuet.Red, FontWeight: menuet.WeightBold},
+			},
+		},
+		menuet.Regular{
+			Runs: []menuet.TextRun{
+				{Text: "Status: "},
+				{Text: "OK", Color: menuet.Green, FontWeight: menuet.WeightBold},
+			},
+		},
+		menuet.Regular{
+			Runs: []menuet.TextRun{
+				{Text: "Build "},
+				{Text: "#1234 ", Color: menuet.Gray, Monospaced: true},
+				{Text: "passed in "},
+				{Text: "42.3s", FontWeight: menuet.WeightSemibold},
+			},
+		},
+		menuet.Regular{
+			Runs: []menuet.TextRun{
+				{Text: "$ ", Color: menuet.Gray, Monospaced: true},
+				{Text: "make release", Monospaced: true},
+			},
+		},
 	}
 }
 

--- a/formatting.go
+++ b/formatting.go
@@ -1,5 +1,42 @@
 package menuet
 
+// Color is an RGBA color for menu-item text. The zero value (all four
+// components zero) means "use the system default color" — i.e. whatever
+// color the menu item would normally render in (which adapts to dark vs.
+// light mode automatically).
+type Color struct {
+	R, G, B, A uint8
+}
+
+// IsZero reports whether c is the zero value. A zero-value Color is
+// interpreted as "use the system default" rather than fully transparent
+// black. To render fully transparent black, set A explicitly to a tiny
+// non-zero value.
+func (c Color) IsZero() bool { return c == Color{} }
+
+// Named colors callers can use without constructing one manually. Choose
+// readable defaults; users can pick custom RGBA when they need to.
+var (
+	Red    = Color{R: 220, G: 50, B: 50, A: 255}
+	Green  = Color{R: 30, G: 160, B: 60, A: 255}
+	Yellow = Color{R: 200, G: 160, B: 0, A: 255}
+	Blue   = Color{R: 0, G: 110, B: 200, A: 255}
+	Gray   = Color{R: 128, G: 128, B: 128, A: 255}
+)
+
+// TextRun is one segment of a styled menu-item title. Multiple runs are
+// concatenated to form the full title with per-segment styling — see
+// Regular.Runs. The zero value of each style field means "inherit" so a
+// run can change just one attribute (e.g. only Color) without disturbing
+// the others.
+type TextRun struct {
+	Text       string
+	Color      Color      // zero = system default
+	FontSize   int        // 0 = inherit from item
+	FontWeight FontWeight // 0 = default
+	Monospaced bool       // true = system monospace font
+}
+
 // FontWeight represents the weight of the font
 type FontWeight float64
 

--- a/menuet.m
+++ b/menuet.m
@@ -48,6 +48,71 @@ MenuetMenu *_rootMenu;
 
 @end
 
+// Build an NSAttributedString for a menu item's title. If runs is non-nil
+// and non-empty, each run is appended with its own per-segment attributes
+// (color, font size, weight, monospace). Otherwise the whole title is
+// styled with the item-level attributes.
+//
+// A run's zero-value Color/FontSize/FontWeight means "inherit from the
+// item-level value" so callers can change just one attribute per run
+// without re-specifying the rest.
+static NSColor *MenuetColorFromDict(NSDictionary *dict) {
+	if (!dict) return nil;
+	NSNumber *r = dict[@"R"];
+	NSNumber *g = dict[@"G"];
+	NSNumber *b = dict[@"B"];
+	NSNumber *a = dict[@"A"];
+	if (!r || !g || !b || !a) return nil;
+	if (r.intValue == 0 && g.intValue == 0 && b.intValue == 0 && a.intValue == 0) {
+		return nil;
+	}
+	return [NSColor colorWithRed:r.floatValue / 255.0
+	                       green:g.floatValue / 255.0
+	                        blue:b.floatValue / 255.0
+	                       alpha:a.floatValue / 255.0];
+}
+
+static NSFont *MenuetFont(CGFloat size, CGFloat weight, BOOL mono) {
+	if (size <= 0) size = 14;
+	if (mono) {
+		return [NSFont monospacedSystemFontOfSize:size weight:weight];
+	}
+	return [NSFont monospacedDigitSystemFontOfSize:size weight:weight];
+}
+
+static NSAttributedString *MenuetBuildAttributedTitle(NSString *text,
+                                                      NSArray *runs,
+                                                      CGFloat itemFontSize,
+                                                      CGFloat itemFontWeight,
+                                                      NSDictionary *itemColorDict,
+                                                      BOOL itemMono) {
+	NSColor *itemColor = MenuetColorFromDict(itemColorDict);
+	if (![runs isKindOfClass:[NSArray class]] || runs.count == 0) {
+		NSMutableDictionary *attrs = [NSMutableDictionary new];
+		attrs[NSFontAttributeName] = MenuetFont(itemFontSize, itemFontWeight, itemMono);
+		if (itemColor) attrs[NSForegroundColorAttributeName] = itemColor;
+		return [[NSAttributedString alloc] initWithString:(text ?: @"") attributes:attrs];
+	}
+	NSMutableAttributedString *result = [NSMutableAttributedString new];
+	for (NSDictionary *run in runs) {
+		if (![run isKindOfClass:[NSDictionary class]]) continue;
+		NSString *segText = run[@"Text"] ?: @"";
+		if (segText.length == 0) continue;
+		NSNumber *fsNum = run[@"FontSize"];
+		NSNumber *fwNum = run[@"FontWeight"];
+		BOOL runMono = [run[@"Monospaced"] boolValue] || itemMono;
+		CGFloat fs = fsNum.intValue > 0 ? fsNum.floatValue : itemFontSize;
+		CGFloat fw = fwNum.floatValue != 0 ? fwNum.floatValue : itemFontWeight;
+		NSColor *runColor = MenuetColorFromDict(run[@"Color"]) ?: itemColor;
+		NSMutableDictionary *attrs = [NSMutableDictionary new];
+		attrs[NSFontAttributeName] = MenuetFont(fs, fw, runMono);
+		if (runColor) attrs[NSForegroundColorAttributeName] = runColor;
+		[result appendAttributedString:[[NSAttributedString alloc] initWithString:segText
+		                                                              attributes:attrs]];
+	}
+	return result;
+}
+
 @implementation MenuetMenu
 - (id)init {
 	self = [super init];
@@ -121,9 +186,12 @@ MenuetMenu *_rootMenu;
 		}
 		NSString *unique = dict[@"Unique"];
 		NSString *text = dict[@"Text"];
+		NSArray *runs = dict[@"Runs"];
 		NSString *imageName = dict[@"Image"];
 		NSNumber *fontSize = dict[@"FontSize"];
 		NSNumber *fontWeight = dict[@"FontWeight"];
+		NSDictionary *itemColor = dict[@"Color"];
+		BOOL itemMono = [dict[@"Monospaced"] boolValue];
 		BOOL state = [dict[@"State"] boolValue];
 		BOOL hasChildren = [dict[@"HasChildren"] boolValue];
 		BOOL clickable = [dict[@"Clickable"] boolValue];
@@ -131,17 +199,9 @@ MenuetMenu *_rootMenu;
 			item =
 				[self insertItemWithTitle:@"" action:nil keyEquivalent:@"" atIndex:i];
 		}
-		NSMutableDictionary *attributes = [NSMutableDictionary new];
-		float size = fontSize.floatValue;
-		if (fontSize == 0) {
-			size = 14;
-		}
-		attributes[NSFontAttributeName] =
-			[NSFont monospacedDigitSystemFontOfSize:size
-			 weight:fontWeight.floatValue];
-		item.attributedTitle =
-			[[NSMutableAttributedString alloc] initWithString:text
-			 attributes:attributes];
+		item.attributedTitle = MenuetBuildAttributedTitle(
+		    text, runs, fontSize.floatValue, fontWeight.floatValue,
+		    itemColor, itemMono);
 		item.target = self;
 		if (clickable) {
 			item.action = @selector(press:);

--- a/menuitem.go
+++ b/menuitem.go
@@ -17,11 +17,18 @@ type MenuItem interface {
 
 // Regular is a standard menu row. Set Text and optionally Clicked
 // (callback when activated) and Children (returns a submenu).
+//
+// For mixed styling within a single row — e.g. "Status: FAILED" where
+// FAILED is red and bold — set Runs to a slice of TextRun. Runs takes
+// precedence over Text when non-empty.
 type Regular struct {
 	Text       string
-	Image      string // In Resources dir or URL, should have height 16
-	FontSize   int    // Default: 14
+	Runs       []TextRun // when non-empty, overrides Text
+	Image      string    // In Resources dir or URL, should have height 16
+	FontSize   int       // Default: 14
 	FontWeight FontWeight
+	Color      Color // zero = system default
+	Monospaced bool
 	State      bool // shows checkmark when set
 
 	Clicked  func()
@@ -66,9 +73,12 @@ type internalItem struct {
 	// MenuItem types — it just reads Type and the matching fields.
 	Type        string
 	Text        string
+	Runs        []TextRun `json:",omitempty"`
 	Image       string
 	FontSize    int
 	FontWeight  FontWeight
+	Color       Color `json:",omitempty"`
+	Monospaced  bool  `json:",omitempty"`
 	State       bool
 	HasChildren bool
 	Clickable   bool
@@ -83,9 +93,12 @@ func buildInternalItem(item MenuItem, unique, parentUnique string) internalItem 
 	switch v := item.(type) {
 	case Regular:
 		out.Text = v.Text
+		out.Runs = v.Runs
 		out.Image = v.Image
 		out.FontSize = v.FontSize
 		out.FontWeight = v.FontWeight
+		out.Color = v.Color
+		out.Monospaced = v.Monospaced
 		out.State = v.State
 		out.Clickable = v.Clicked != nil
 		out.HasChildren = v.Children != nil

--- a/richtext_test.go
+++ b/richtext_test.go
@@ -1,0 +1,87 @@
+package menuet
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestColorZeroIsDefault(t *testing.T) {
+	if !(Color{}).IsZero() {
+		t.Error("Color{} should be zero")
+	}
+	if (Color{A: 255}).IsZero() {
+		t.Error("Color with any non-zero component should NOT be zero")
+	}
+	if Red.IsZero() {
+		t.Error("Red should not be zero")
+	}
+}
+
+func TestRegularRunsSerializeToJSON(t *testing.T) {
+	item := buildInternalItem(
+		Regular{
+			Text: "fallback",
+			Runs: []TextRun{
+				{Text: "Status: "},
+				{Text: "FAILED", Color: Red, FontWeight: WeightBold},
+			},
+		},
+		"u", "p",
+	)
+	b, err := json.Marshal(item)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(b)
+	// The ObjC side reads "Runs" when non-empty; "Text" is used otherwise.
+	for _, want := range []string{
+		`"Text":"fallback"`,
+		`"Runs":[`,
+		`"Text":"Status: "`,
+		`"Text":"FAILED"`,
+		`"Color":{"R":220,"G":50,"B":50,"A":255}`,
+		`"FontWeight":0.4`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("JSON missing %q\nfull: %s", want, got)
+		}
+	}
+}
+
+func TestRegularWithoutRunsOmitsRunsKey(t *testing.T) {
+	item := buildInternalItem(Regular{Text: "hello"}, "u", "p")
+	b, err := json.Marshal(item)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), `"Runs":`) {
+		t.Errorf("empty Runs should be omitted; got: %s", b)
+	}
+}
+
+func TestRegularRunsPlusItemLevelColor(t *testing.T) {
+	// Item-level Color and Monospaced apply to runs that don't override them.
+	item := buildInternalItem(
+		Regular{
+			Color:      Gray,
+			Monospaced: true,
+			Runs: []TextRun{
+				{Text: "inherits gray + mono"},
+				{Text: "overrides color", Color: Red},
+			},
+		},
+		"u", "p",
+	)
+	b, _ := json.Marshal(item)
+	got := string(b)
+	// Item Color should appear at the top level even when Runs is set —
+	// the ObjC side uses it as the inherited default for runs whose own
+	// Color is the zero value.
+	if !strings.Contains(got, `"Color":{"R":128,"G":128,"B":128,"A":255}`) {
+		t.Errorf("item Color missing\nfull: %s", got)
+	}
+	if !strings.Contains(got, `"Monospaced":true`) {
+		t.Errorf("item Monospaced missing\nfull: %s", got)
+	}
+}


### PR DESCRIPTION
First of three planned feature releases on the menubar-app polish theme.

## What's new

Mixed-style text in menu items. \"Status: FAILED\" with red bold FAILED, \"Build #1234 passed in 42.3s\" with gray-monospace build number — common menubar-app status displays that previously needed icons or workarounds.

\`\`\`go
menuet.Regular{
    Runs: []menuet.TextRun{
        {Text: \"Status: \"},
        {Text: \"FAILED\", Color: menuet.Red, FontWeight: menuet.WeightBold},
    },
}
\`\`\`

Simple cases get item-level fields:

\`\`\`go
menuet.Regular{
    Text:  \"Critical warning\",
    Color: menuet.Red,
}
\`\`\`

## API additions

  - \`menuet.Color\` (R,G,B,A uint8) — zero value = system default (dark-mode-aware)
  - Named: \`menuet.Red\`, \`Green\`, \`Yellow\`, \`Blue\`, \`Gray\`
  - \`menuet.TextRun\` — one styled segment
  - \`Regular.Runs\` — \`[]TextRun\` when non-empty overrides \`Text\`
  - \`Regular.Color\` — applies item-wide or as default for runs
  - \`Regular.Monospaced\` — same

Backward compatible — existing \`Regular{Text: \"…\"}\` items unchanged.

## Verification

  - 4 new unit tests in \`richtext_test.go\` cover color zero-value, JSON shape with/without Runs, and item-level inheritance into runs
  - \`cmd/catalog\` gains a \"Rich text\" submenu with 7 examples covering item-level color/monospace, two-run status badges, and multi-run mixed styling
  - Catalog verified interactively