### PR TITLE
v2.5.0: Global hotkeys + menu key equivalents

### DIFF
--- a/cmd/catalog/catalog.go
+++ b/cmd/catalog/catalog.go
@@ -128,6 +128,32 @@ func menuItems() []menuet.MenuItem {
 			Text:     "Rich text",
 			Children: richTextDemo,
 		},
+		menuet.Regular{
+			Text:     "Hotkeys",
+			Children: hotkeysDemo,
+		},
+	}
+}
+
+var hotkeyFireCount int
+
+func hotkeysDemo() []menuet.MenuItem {
+	return []menuet.MenuItem{
+		menuet.Regular{
+			Text:     fmt.Sprintf("Cmd+Shift+M fired %d time(s)", hotkeyFireCount),
+			Shortcut: &menuet.Shortcut{KeyCode: menuet.KeyM, Modifiers: menuet.ModCmd | menuet.ModShift},
+			Clicked: func() {
+				hotkeyFireCount++
+				menuet.App().MenuChanged()
+			},
+		},
+		menuet.Regular{
+			Text:     "Cmd+Alt+1 → flash an alert",
+			Shortcut: &menuet.Shortcut{KeyCode: menuet.Key1, Modifiers: menuet.ModCmd | menuet.ModAlt},
+			Clicked: func() {
+				menuet.App().Alert(menuet.Alert{MessageText: "Cmd+Alt+1 fired"})
+			},
+		},
 	}
 }
 

--- a/hotkey.go
+++ b/hotkey.go
@@ -1,0 +1,155 @@
+package menuet
+
+/*
+#cgo CFLAGS: -x objective-c
+#cgo LDFLAGS: -framework Cocoa -framework Carbon
+
+#import <Cocoa/Cocoa.h>
+
+void registerHotkey(uint32_t id, uint32_t keyCode, uint32_t modifiers);
+void unregisterHotkey(uint32_t id);
+*/
+import "C"
+import (
+	"log"
+	"sync"
+)
+
+// ModifierMask is a bitmask of keyboard modifier keys for a Shortcut.
+// OR the constants together: ModCmd|ModShift.
+type ModifierMask uint32
+
+// Modifier flags. Match the values Carbon's RegisterEventHotKey expects.
+const (
+	ModCmd   ModifierMask = 1 << 8  // cmdKey
+	ModShift ModifierMask = 1 << 9  // shiftKey
+	ModAlt   ModifierMask = 1 << 11 // optionKey
+	ModCtrl  ModifierMask = 1 << 12 // controlKey
+)
+
+// Shortcut is a global keyboard shortcut. When set on a Regular menu item,
+// the shortcut both:
+//
+//   - displays in the menu like a standard Apple shortcut (⌘N etc.), and
+//   - fires the item's Clicked callback when pressed system-wide, even
+//     when this app isn't frontmost
+//
+// Identical (KeyCode, Modifiers) tuples across multiple menu items are
+// not allowed — only the first registered wins; subsequent ones are
+// silently ignored. Pick distinct shortcuts per action.
+type Shortcut struct {
+	KeyCode   uint16
+	Modifiers ModifierMask
+}
+
+// IsZero reports whether s is the zero value (no key and no modifiers).
+func (s Shortcut) IsZero() bool { return s.KeyCode == 0 && s.Modifiers == 0 }
+
+// macOS virtual key codes. Lowercase letters in QWERTY layout. Not
+// exhaustive — add as needed.
+const (
+	KeyA = 0
+	KeyB = 11
+	KeyC = 8
+	KeyD = 2
+	KeyE = 14
+	KeyF = 3
+	KeyG = 5
+	KeyH = 4
+	KeyI = 34
+	KeyJ = 38
+	KeyK = 40
+	KeyL = 37
+	KeyM = 46
+	KeyN = 45
+	KeyO = 31
+	KeyP = 35
+	KeyQ = 12
+	KeyR = 15
+	KeyS = 1
+	KeyT = 17
+	KeyU = 32
+	KeyV = 9
+	KeyW = 13
+	KeyX = 7
+	KeyY = 16
+	KeyZ = 6
+
+	Key0 = 29
+	Key1 = 18
+	Key2 = 19
+	Key3 = 20
+	Key4 = 21
+	Key5 = 23
+	Key6 = 22
+	Key7 = 26
+	Key8 = 28
+	Key9 = 25
+
+	KeySpace  = 49
+	KeyReturn = 36
+	KeyTab    = 48
+	KeyEsc    = 53
+
+	KeyF1  = 122
+	KeyF2  = 120
+	KeyF3  = 99
+	KeyF4  = 118
+	KeyF5  = 96
+	KeyF6  = 97
+	KeyF7  = 98
+	KeyF8  = 100
+	KeyF9  = 101
+	KeyF10 = 109
+	KeyF11 = 103
+	KeyF12 = 111
+
+	KeyLeft  = 123
+	KeyRight = 124
+	KeyDown  = 125
+	KeyUp    = 126
+)
+
+// hotkeyRegistry tracks active global hotkeys so the cgo callback can
+// route incoming triggers to the right Go callback. Keyed by the uint32
+// ID we hand to Carbon at registration time.
+var (
+	hotkeyMu       sync.RWMutex
+	hotkeyCallback = map[uint32]func(){}
+	hotkeyByTuple  = map[Shortcut]uint32{} // dedup identical shortcuts
+	hotkeyNextID   uint32                  // monotonic; never reuse
+)
+
+// registerHotkey assigns an ID for s and registers a Carbon hotkey that
+// invokes action when fired. If s is already registered, the second
+// registration is ignored (only the first action wins) and the original
+// ID is returned. Returns 0 if registration fails (e.g. duplicate).
+func registerGlobalHotkey(s Shortcut, action func()) uint32 {
+	if s.IsZero() || action == nil {
+		return 0
+	}
+	hotkeyMu.Lock()
+	if id, ok := hotkeyByTuple[s]; ok {
+		hotkeyMu.Unlock()
+		return id
+	}
+	hotkeyNextID++
+	id := hotkeyNextID
+	hotkeyCallback[id] = action
+	hotkeyByTuple[s] = id
+	hotkeyMu.Unlock()
+	C.registerHotkey(C.uint32_t(id), C.uint32_t(s.KeyCode), C.uint32_t(s.Modifiers))
+	return id
+}
+
+//export hotkeyFired
+func hotkeyFired(id C.uint32_t) {
+	hotkeyMu.RLock()
+	cb := hotkeyCallback[uint32(id)]
+	hotkeyMu.RUnlock()
+	if cb == nil {
+		log.Printf("menuet: hotkey id=%d fired with no callback registered", id)
+		return
+	}
+	go cb()
+}

--- a/hotkey_test.go
+++ b/hotkey_test.go
@@ -1,0 +1,87 @@
+package menuet
+
+import (
+	"sync/atomic"
+	"testing"
+)
+
+func resetHotkeyRegistry() {
+	hotkeyMu.Lock()
+	hotkeyCallback = map[uint32]func(){}
+	hotkeyByTuple = map[Shortcut]uint32{}
+	hotkeyNextID = 0
+	hotkeyMu.Unlock()
+}
+
+func TestShortcutZero(t *testing.T) {
+	if !(Shortcut{}).IsZero() {
+		t.Error("Shortcut{} should be zero")
+	}
+	if (Shortcut{KeyCode: KeyN}).IsZero() {
+		t.Error("Shortcut with KeyCode set should NOT be zero")
+	}
+	if (Shortcut{Modifiers: ModCmd}).IsZero() {
+		t.Error("Shortcut with Modifiers set should NOT be zero")
+	}
+}
+
+func TestRegisterGlobalHotkeyAssignsID(t *testing.T) {
+	resetHotkeyRegistry()
+	defer resetHotkeyRegistry()
+	id := registerGlobalHotkey(
+		Shortcut{KeyCode: KeyN, Modifiers: ModCmd | ModShift},
+		func() {},
+	)
+	if id == 0 {
+		t.Fatal("expected non-zero id on successful registration")
+	}
+}
+
+func TestRegisterGlobalHotkeyDedupesIdenticalShortcut(t *testing.T) {
+	resetHotkeyRegistry()
+	defer resetHotkeyRegistry()
+	sc := Shortcut{KeyCode: KeyN, Modifiers: ModCmd}
+	id1 := registerGlobalHotkey(sc, func() {})
+	id2 := registerGlobalHotkey(sc, func() {}) // second action should be ignored
+	if id1 != id2 {
+		t.Errorf("expected same id for duplicate shortcut, got id1=%d id2=%d", id1, id2)
+	}
+}
+
+func TestRegisterGlobalHotkeyIgnoresZero(t *testing.T) {
+	resetHotkeyRegistry()
+	defer resetHotkeyRegistry()
+	id := registerGlobalHotkey(Shortcut{}, func() {})
+	if id != 0 {
+		t.Errorf("zero shortcut should return id=0, got %d", id)
+	}
+}
+
+func TestRegisterGlobalHotkeyIgnoresNilAction(t *testing.T) {
+	resetHotkeyRegistry()
+	defer resetHotkeyRegistry()
+	id := registerGlobalHotkey(Shortcut{KeyCode: KeyN, Modifiers: ModCmd}, nil)
+	if id != 0 {
+		t.Errorf("nil action should return id=0, got %d", id)
+	}
+}
+
+func TestHotkeyFiredInvokesCallback(t *testing.T) {
+	resetHotkeyRegistry()
+	defer resetHotkeyRegistry()
+	var fired int32
+	id := registerGlobalHotkey(
+		Shortcut{KeyCode: KeySpace, Modifiers: ModCmd | ModAlt},
+		func() { atomic.StoreInt32(&fired, 1) },
+	)
+	hotkeyMu.RLock()
+	cb := hotkeyCallback[id]
+	hotkeyMu.RUnlock()
+	if cb == nil {
+		t.Fatal("callback not stored")
+	}
+	cb()
+	if atomic.LoadInt32(&fired) != 1 {
+		t.Errorf("callback didn't fire")
+	}
+}

--- a/menuet.go
+++ b/menuet.go
@@ -2,7 +2,7 @@ package menuet
 
 /*
 #cgo CFLAGS: -x objective-c
-#cgo LDFLAGS: -framework Cocoa
+#cgo LDFLAGS: -framework Cocoa -framework Carbon
 
 #import <Cocoa/Cocoa.h>
 

--- a/menuet.m
+++ b/menuet.m
@@ -1,8 +1,11 @@
 #import <Cocoa/Cocoa.h>
 #import <UserNotifications/UserNotifications.h>
+#import <Carbon/Carbon.h>
 
 #import "NSImage+Resize.h"
 #import "menuet.h"
+
+void hotkeyFired(uint32_t id);
 
 void itemClicked(const char *);
 void notificationRespond(const char *, const char *);
@@ -23,6 +26,60 @@ void topLevelClicked();
 // clears items with this tag before rebuilding so a menu refresh doesn't
 // confuse search results with user-supplied items.
 #define MENUET_SEARCH_RESULT_TAG 31337
+
+// Global-hotkey Carbon plumbing. Each Shortcut registered from Go gets an
+// EventHotKeyRef stored here keyed by the Go-assigned uint32 ID, so we can
+// unregister on demand. The shared event handler dispatches incoming
+// kEventHotKeyPressed events back into Go via hotkeyFired().
+static NSMutableDictionary<NSNumber *, NSValue *> *MenuetHotkeyRefs;
+static EventHandlerRef MenuetHotkeyHandler;
+
+static OSStatus MenuetHotkeyEventCallback(EventHandlerCallRef handler,
+                                          EventRef event,
+                                          void *userData) {
+	EventHotKeyID id;
+	OSStatus status = GetEventParameter(event, kEventParamDirectObject,
+	                                     typeEventHotKeyID, NULL,
+	                                     sizeof(id), NULL, &id);
+	if (status != noErr) return status;
+	hotkeyFired(id.id);
+	return noErr;
+}
+
+static void MenuetEnsureHotkeyHandler(void) {
+	if (MenuetHotkeyHandler) return;
+	MenuetHotkeyRefs = [NSMutableDictionary new];
+	EventTypeSpec evt = { kEventClassKeyboard, kEventHotKeyPressed };
+	InstallApplicationEventHandler(MenuetHotkeyEventCallback, 1, &evt,
+	                                NULL, &MenuetHotkeyHandler);
+}
+
+void registerHotkey(uint32_t goID, uint32_t keyCode, uint32_t modifiers) {
+	dispatch_async(dispatch_get_main_queue(), ^{
+		MenuetEnsureHotkeyHandler();
+		EventHotKeyID hkID = { .signature = 'menu', .id = goID };
+		EventHotKeyRef ref = NULL;
+		OSStatus status = RegisterEventHotKey(keyCode, modifiers, hkID,
+		                                       GetApplicationEventTarget(),
+		                                       0, &ref);
+		if (status != noErr) {
+			NSLog(@"menuet: RegisterEventHotKey failed (status=%d) for id=%u",
+			       (int)status, goID);
+			return;
+		}
+		MenuetHotkeyRefs[@(goID)] = [NSValue valueWithPointer:ref];
+	});
+}
+
+void unregisterHotkey(uint32_t goID) {
+	dispatch_async(dispatch_get_main_queue(), ^{
+		NSValue *boxed = MenuetHotkeyRefs[@(goID)];
+		if (!boxed) return;
+		EventHotKeyRef ref = (EventHotKeyRef)boxed.pointerValue;
+		UnregisterEventHotKey(ref);
+		[MenuetHotkeyRefs removeObjectForKey:@(goID)];
+	});
+}
 
 @class MenuetMenu;
 
@@ -47,6 +104,87 @@ MenuetMenu *_rootMenu;
 @property(nonatomic, assign) BOOL open;
 
 @end
+
+// Convert one of Apple's virtual key codes (the same KeyCode values our
+// Go-side Key constants use) to the NSString form NSMenuItem.keyEquivalent
+// expects. Returns @"" for codes we don't have a printable mapping for.
+static NSString *MenuetKeyEquivalentStringForCode(int keyCode) {
+	// Letter keys, layout-independent — match the Go-side constants.
+	switch (keyCode) {
+		case 0:  return @"a";
+		case 11: return @"b";
+		case 8:  return @"c";
+		case 2:  return @"d";
+		case 14: return @"e";
+		case 3:  return @"f";
+		case 5:  return @"g";
+		case 4:  return @"h";
+		case 34: return @"i";
+		case 38: return @"j";
+		case 40: return @"k";
+		case 37: return @"l";
+		case 46: return @"m";
+		case 45: return @"n";
+		case 31: return @"o";
+		case 35: return @"p";
+		case 12: return @"q";
+		case 15: return @"r";
+		case 1:  return @"s";
+		case 17: return @"t";
+		case 32: return @"u";
+		case 9:  return @"v";
+		case 13: return @"w";
+		case 7:  return @"x";
+		case 16: return @"y";
+		case 6:  return @"z";
+
+		case 29: return @"0";
+		case 18: return @"1";
+		case 19: return @"2";
+		case 20: return @"3";
+		case 21: return @"4";
+		case 23: return @"5";
+		case 22: return @"6";
+		case 26: return @"7";
+		case 28: return @"8";
+		case 25: return @"9";
+
+		case 49: return @" ";                      // space
+		case 36: return [NSString stringWithFormat:@"%C", (unichar)NSCarriageReturnCharacter];
+		case 48: return @"\t";
+		case 53: return [NSString stringWithFormat:@"%C", (unichar)0x1B]; // escape
+
+		case 122: return [NSString stringWithFormat:@"%C", (unichar)NSF1FunctionKey];
+		case 120: return [NSString stringWithFormat:@"%C", (unichar)NSF2FunctionKey];
+		case 99:  return [NSString stringWithFormat:@"%C", (unichar)NSF3FunctionKey];
+		case 118: return [NSString stringWithFormat:@"%C", (unichar)NSF4FunctionKey];
+		case 96:  return [NSString stringWithFormat:@"%C", (unichar)NSF5FunctionKey];
+		case 97:  return [NSString stringWithFormat:@"%C", (unichar)NSF6FunctionKey];
+		case 98:  return [NSString stringWithFormat:@"%C", (unichar)NSF7FunctionKey];
+		case 100: return [NSString stringWithFormat:@"%C", (unichar)NSF8FunctionKey];
+		case 101: return [NSString stringWithFormat:@"%C", (unichar)NSF9FunctionKey];
+		case 109: return [NSString stringWithFormat:@"%C", (unichar)NSF10FunctionKey];
+		case 103: return [NSString stringWithFormat:@"%C", (unichar)NSF11FunctionKey];
+		case 111: return [NSString stringWithFormat:@"%C", (unichar)NSF12FunctionKey];
+
+		case 123: return [NSString stringWithFormat:@"%C", (unichar)NSLeftArrowFunctionKey];
+		case 124: return [NSString stringWithFormat:@"%C", (unichar)NSRightArrowFunctionKey];
+		case 125: return [NSString stringWithFormat:@"%C", (unichar)NSDownArrowFunctionKey];
+		case 126: return [NSString stringWithFormat:@"%C", (unichar)NSUpArrowFunctionKey];
+	}
+	return @"";
+}
+
+// Convert the Carbon-bit modifier mask we use in Go to the AppKit
+// NSEventModifierFlag bits NSMenuItem.keyEquivalentModifierMask expects.
+static NSEventModifierFlags MenuetModifierMaskFromCarbon(uint32_t carbon) {
+	NSEventModifierFlags mask = 0;
+	if (carbon & cmdKey)     mask |= NSEventModifierFlagCommand;
+	if (carbon & shiftKey)   mask |= NSEventModifierFlagShift;
+	if (carbon & optionKey)  mask |= NSEventModifierFlagOption;
+	if (carbon & controlKey) mask |= NSEventModifierFlagControl;
+	return mask;
+}
 
 // Build an NSAttributedString for a menu item's title. If runs is non-nil
 // and non-empty, each run is appended with its own per-segment attributes
@@ -202,6 +340,18 @@ static NSAttributedString *MenuetBuildAttributedTitle(NSString *text,
 		item.attributedTitle = MenuetBuildAttributedTitle(
 		    text, runs, fontSize.floatValue, fontWeight.floatValue,
 		    itemColor, itemMono);
+		// Shortcut display in the menu (⌘N etc.). The global hotkey
+		// registration happens Go-side in buildInternalItem.
+		NSDictionary *shortcut = dict[@"Shortcut"];
+		if ([shortcut isKindOfClass:[NSDictionary class]]) {
+			int kc = [shortcut[@"KeyCode"] intValue];
+			uint32_t mods = [shortcut[@"Modifiers"] unsignedIntValue];
+			item.keyEquivalent = MenuetKeyEquivalentStringForCode(kc);
+			item.keyEquivalentModifierMask = MenuetModifierMaskFromCarbon(mods);
+		} else {
+			item.keyEquivalent = @"";
+			item.keyEquivalentModifierMask = 0;
+		}
 		item.target = self;
 		if (clickable) {
 			item.action = @selector(press:);

--- a/menuitem.go
+++ b/menuitem.go
@@ -31,6 +31,13 @@ type Regular struct {
 	Monospaced bool
 	State      bool // shows checkmark when set
 
+	// Shortcut, when non-nil, displays in the menu like a standard Apple
+	// shortcut (⌘N etc.) AND registers a system-wide hotkey: pressing the
+	// key combination triggers Clicked even when this app isn't frontmost.
+	// Identical Shortcuts across multiple Regular items: only the first
+	// wins; subsequent registrations are silently ignored.
+	Shortcut *Shortcut
+
 	Clicked  func()
 	Children func() []MenuItem
 }
@@ -77,8 +84,9 @@ type internalItem struct {
 	Image       string
 	FontSize    int
 	FontWeight  FontWeight
-	Color       Color `json:",omitempty"`
-	Monospaced  bool  `json:",omitempty"`
+	Color       Color     `json:",omitempty"`
+	Monospaced  bool      `json:",omitempty"`
+	Shortcut    *Shortcut `json:",omitempty"`
 	State       bool
 	HasChildren bool
 	Clickable   bool
@@ -99,9 +107,15 @@ func buildInternalItem(item MenuItem, unique, parentUnique string) internalItem 
 		out.FontWeight = v.FontWeight
 		out.Color = v.Color
 		out.Monospaced = v.Monospaced
+		out.Shortcut = v.Shortcut
 		out.State = v.State
 		out.Clickable = v.Clicked != nil
 		out.HasChildren = v.Children != nil
+		// Register the global hotkey, with the click callback as the
+		// action. Duplicate registrations are deduped in hotkey.go.
+		if v.Shortcut != nil && !v.Shortcut.IsZero() && v.Clicked != nil {
+			registerGlobalHotkey(*v.Shortcut, v.Clicked)
+		}
 	case Separator:
 		out.Type = "separator"
 	case Search:


### PR DESCRIPTION
Second of three planned feature releases.

\`\`\`go
menuet.Regular{
    Text: \"Quick Capture\",
    Shortcut: &menuet.Shortcut{
        KeyCode: menuet.KeySpace,
        Modifiers: menuet.ModCmd | menuet.ModShift,
    },
    Clicked: func() { showCapture() },
}
\`\`\`

Both paths fire \`Clicked\`:

  - User types the shortcut while in another app → Carbon \`RegisterEventHotKey\` fires it globally
  - User opens the menu and clicks the item → the visible \`⌘⇧Space\` shortcut shows next to it, fired via \`NSMenuItem\` action

## API

  - \`menuet.ModifierMask\` with \`ModCmd\` / \`ModShift\` / \`ModAlt\` / \`ModCtrl\`
  - \`menuet.Shortcut{KeyCode, Modifiers}\` with \`IsZero()\` predicate
  - Full virtual-key-code constants: \`KeyA\`..\`KeyZ\`, \`Key0\`..\`Key9\`, \`KeySpace\`, \`KeyReturn\`, \`KeyTab\`, \`KeyEsc\`, \`KeyF1\`..\`KeyF12\`, arrows
  - \`Regular.Shortcut\` pointer field

Backward compatible — existing items without a \`Shortcut\` behave unchanged.

## Verification

  - 6 new unit tests cover registry dedup, zero-shortcut/zero-action skip, and callback dispatch
  - cmd/catalog gains a \"Hotkeys\" submenu: Cmd+Shift+M (counter in item title) and Cmd+Alt+1 (flashes an alert)
  - Catalog verified interactively

Re-adds \`-framework Carbon\` to cgo LDFLAGS (was removed in v2.3.1 when we dropped the Search click sim — back now for legitimate non-deprecated use of the Carbon Event Manager hotkey APIs).