### PR TITLE
v2.6.0: Modern login items via SMAppService (LaunchAgent fallback)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,12 @@ requirements are enforced by macOS, not by menuet:
   no-op for a loose executable. The app also needs to be code-signed —
   ad-hoc signing is not enough; you need a Developer ID signature (or full
   notarization for distribution).
-* **Start at Login** writes a launchd plist that points at the executable
-  path. You'll typically want that path to be the binary inside your `.app`
-  bundle, not a `go run` temp directory.
+* **Start at Login** prefers the macOS 13+ Service Management framework
+  (`SMAppService`) when available, which puts the app under System
+  Settings → Login Items so the user can revoke it from the standard
+  place. For older macOS or unsigned dev builds the older LaunchAgent
+  plist path is used as a fallback. Either backend wants the app to be
+  bundled.
 * **Auto-update** moves a new `.app` bundle on top of the running one, so it
   obviously needs a bundle to update.
 

--- a/menuet.go
+++ b/menuet.go
@@ -2,7 +2,7 @@ package menuet
 
 /*
 #cgo CFLAGS: -x objective-c
-#cgo LDFLAGS: -framework Cocoa -framework Carbon
+#cgo LDFLAGS: -framework Cocoa -framework Carbon -framework ServiceManagement
 
 #import <Cocoa/Cocoa.h>
 

--- a/menuet.m
+++ b/menuet.m
@@ -1,11 +1,60 @@
 #import <Cocoa/Cocoa.h>
 #import <UserNotifications/UserNotifications.h>
 #import <Carbon/Carbon.h>
+#import <ServiceManagement/ServiceManagement.h>
 
 #import "NSImage+Resize.h"
 #import "menuet.h"
 
 void hotkeyFired(uint32_t id);
+
+// SMAppService is macOS 13+. The wrapper functions return:
+//   -1 = API unavailable on this macOS
+//    0 = success / not registered
+//    1 = registered / requires user approval
+//    2 = registration error (e.g. unsigned bundle — caller should fall back)
+//    3 = not found (status only)
+int menuetSMAppServiceRegister(void) {
+	if (@available(macOS 13.0, *)) {
+		SMAppService *service = [SMAppService mainAppService];
+		NSError *err = nil;
+		BOOL ok = [service registerAndReturnError:&err];
+		if (ok) return 0;
+		if (err) {
+			NSLog(@"menuet: SMAppService register failed: %@", err);
+		}
+		return 2;
+	}
+	return -1;
+}
+
+int menuetSMAppServiceUnregister(void) {
+	if (@available(macOS 13.0, *)) {
+		SMAppService *service = [SMAppService mainAppService];
+		NSError *err = nil;
+		BOOL ok = [service unregisterAndReturnError:&err];
+		if (ok) return 0;
+		if (err) {
+			NSLog(@"menuet: SMAppService unregister failed: %@", err);
+		}
+		return 2;
+	}
+	return -1;
+}
+
+int menuetSMAppServiceStatus(void) {
+	if (@available(macOS 13.0, *)) {
+		SMAppService *service = [SMAppService mainAppService];
+		switch (service.status) {
+			case SMAppServiceStatusEnabled:           return 1;
+			case SMAppServiceStatusRequiresApproval:  return 1;
+			case SMAppServiceStatusNotRegistered:     return 0;
+			case SMAppServiceStatusNotFound:          return 3;
+		}
+		return 0;
+	}
+	return -1;
+}
 
 void itemClicked(const char *);
 void notificationRespond(const char *, const char *);

--- a/startup.go
+++ b/startup.go
@@ -1,5 +1,12 @@
 package menuet
 
+/*
+int menuetSMAppServiceRegister(void);
+int menuetSMAppServiceUnregister(void);
+int menuetSMAppServiceStatus(void);
+*/
+import "C"
+
 import (
 	"bytes"
 	"log"
@@ -9,6 +16,27 @@ import (
 	"sync"
 	"text/template"
 )
+
+// smAppServiceRegister attempts the macOS 13+ Service Management path.
+// Returns true on success. Returns false if the API is unavailable
+// (older macOS) or if registration failed (e.g. the bundle isn't signed
+// in a way SMAppService accepts) — caller should fall back to the
+// LaunchAgent path.
+func smAppServiceRegister() bool {
+	return int(C.menuetSMAppServiceRegister()) == 0
+}
+
+func smAppServiceUnregister() bool {
+	return int(C.menuetSMAppServiceUnregister()) == 0
+}
+
+// smAppServiceEnabled reports whether the SMAppService backend currently
+// considers this app registered (enabled OR requires-approval — both
+// mean "set up via SMAppService"). Returns false if the API is
+// unavailable or the app isn't registered.
+func smAppServiceEnabled() bool {
+	return int(C.menuetSMAppServiceStatus()) == 1
+}
 
 func (a *Application) getStartupPath() string {
 	if a.Label == "" {
@@ -24,6 +52,12 @@ func (a *Application) getStartupPath() string {
 }
 
 func (a *Application) runningAtStartup() bool {
+	// SMAppService is the modern (macOS 13+) backend and what users
+	// expect: the System Settings → Login Items panel reflects it. Check
+	// it first; fall back to looking for our LaunchAgent plist.
+	if smAppServiceEnabled() {
+		return true
+	}
 	path := a.getStartupPath()
 	if path == "" {
 		return false
@@ -33,11 +67,15 @@ func (a *Application) runningAtStartup() bool {
 }
 
 func (a *Application) removeStartupItem() {
+	// Remove from both backends so we don't leave stale entries behind
+	// if the user previously used one and now the other (or both got
+	// registered during a transitional period).
+	smAppServiceUnregister()
 	path := a.getStartupPath()
 	if path == "" {
 		return
 	}
-	if err := os.Remove(path); err != nil {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		log.Printf("os.Remove: %v", err)
 	}
 }
@@ -63,6 +101,17 @@ func renderLaunchdPlist(data launchdPlistData) (string, error) {
 }
 
 func (a *Application) addStartupItem() {
+	// macOS 13+ Service Management. Shows the app under System Settings
+	// → Login Items so the user can revoke it from the standard place.
+	// Requires the bundle to be signed in a way SMAppService accepts
+	// (Developer ID or App Store); ad-hoc-signed dev builds will fail
+	// here and we fall through to the LaunchAgent path.
+	if smAppServiceRegister() {
+		return
+	}
+
+	// Legacy LaunchAgent plist. Works for unsigned/ad-hoc dev builds and
+	// for macOS 12 and earlier (where SMAppService doesn't exist).
 	path := a.getStartupPath()
 	if path == "" {
 		return


### PR DESCRIPTION
Third and final feature release in the menubar-app polish series.

## What changes

Login items use macOS 13's \`SMAppService\` API when available. Apps appear under System Settings → Login Items so the user can revoke them from the standard place, instead of having to know about and manually delete a LaunchAgent plist.

For older macOS or unsigned dev builds, the existing LaunchAgent plist path is the fallback so dev/test workflows are unchanged.

## API surface — unchanged

Existing apps using \`Application.Label\` keep working. The backend selection is internal:

  - \`addStartupItem\` tries SMAppService first, falls back to LaunchAgent
  - \`removeStartupItem\` cleans up both backends
  - \`runningAtStartup\` returns true if either backend considers the app registered

## Implementation

  - menuet.m: \`SMAppService\` wrappers (register/unregister/status) guarded with \`@available(macOS 13.0, *)\`, returning -1 when the API isn't present so the Go side falls through cleanly
  - startup.go: cgo plumbing for the three calls
  - cgo LDFLAGS gain \`-framework ServiceManagement\`
  - README updated under \"Running as a real macOS app\"

Existing 7 startup tests still pass — the LaunchAgent path is untouched, just no longer the default on macOS 13+ when SMAppService can take it.