### PR TITLE
v2.7.0: sportsbar rich-text additions (title runs, semantic colors, subtitles, badges)

### DIFF
--- a/cmd/catalog/catalog.go
+++ b/cmd/catalog/catalog.go
@@ -160,6 +160,38 @@ func hotkeysDemo() []menuet.MenuItem {
 func richTextDemo() []menuet.MenuItem {
 	return []menuet.MenuItem{
 		menuet.Regular{
+			Runs: []menuet.TextRun{
+				{Text: "Semantic ", Color: menuet.LabelPrimary},
+				{Text: "colors ", Color: menuet.LabelSecondary},
+				{Text: "adapt ", Color: menuet.LabelTertiary},
+				{Text: "to dark mode", Color: menuet.LabelQuaternary},
+			},
+		},
+		menuet.Regular{
+			Runs: []menuet.TextRun{
+				{Text: "Status: ", Color: menuet.LabelSecondary},
+				{Text: "FAILED", Color: menuet.SystemRed, FontWeight: menuet.WeightBold},
+			},
+		},
+		menuet.Regular{
+			Runs: []menuet.TextRun{
+				{Text: "GSW 71 – 68 MIN  "},
+				{Text: "LIVE", Color: menuet.SystemRed, Badge: true},
+			},
+			Subtitle: []menuet.TextRun{
+				{Text: "NBA · Q3 5:42"},
+			},
+		},
+		menuet.Regular{
+			Runs: []menuet.TextRun{
+				{Text: "$ ", Color: menuet.LabelTertiary, Monospaced: true},
+				{Text: "make release", Monospaced: true},
+			},
+			Subtitle: []menuet.TextRun{
+				{Text: "Builds + signs + uploads zip to GitHub"},
+			},
+		},
+		menuet.Regular{
 			Text:  "Item-level color (red)",
 			Color: menuet.Red,
 		},
@@ -338,6 +370,20 @@ func changeTitle() []menuet.MenuItem {
 				menuet.App().SetMenuState(&menuet.MenuState{
 					Title: "Catalog",
 					Image: "clipboard",
+				})
+			},
+		},
+		menuet.Regular{
+			Text: "Runs in the title (live score)",
+			Clicked: func() {
+				menuet.App().SetMenuState(&menuet.MenuState{
+					Runs: []menuet.TextRun{
+						{Text: "● ", Color: menuet.SystemRed},
+						{Text: "GSW ", FontWeight: menuet.WeightSemibold},
+						{Text: "71", FontWeight: menuet.WeightBold, Monospaced: true},
+						{Text: "–68", Color: menuet.LabelSecondary, Monospaced: true},
+						{Text: " MIN", Color: menuet.LabelSecondary},
+					},
 				})
 			},
 		},

--- a/formatting.go
+++ b/formatting.go
@@ -1,21 +1,30 @@
 package menuet
 
-// Color is an RGBA color for menu-item text. The zero value (all four
-// components zero) means "use the system default color" — i.e. whatever
-// color the menu item would normally render in (which adapts to dark vs.
-// light mode automatically).
+// Color is a color for menu-item text. The zero value means "use the
+// system default" — whatever color the menu item would normally render
+// in (adapts to dark vs. light mode automatically).
+//
+// Two ways to specify a color:
+//   - RGBA via R, G, B, A. Fixed pixel values. Does not adapt to
+//     appearance — usually fine for branded colors that need to match
+//     across light and dark mode.
+//   - Semantic: a name like "labelColor" or "systemRed" that the ObjC
+//     bridge resolves to an AppKit dynamic NSColor at draw time, so the
+//     value shifts with appearance automatically. Prefer this for
+//     hierarchy and accent colors.
+//
+// When Semantic is non-empty it takes precedence over RGBA.
 type Color struct {
 	R, G, B, A uint8
+	Semantic   string `json:",omitempty"`
 }
 
-// IsZero reports whether c is the zero value. A zero-value Color is
-// interpreted as "use the system default" rather than fully transparent
-// black. To render fully transparent black, set A explicitly to a tiny
-// non-zero value.
+// IsZero reports whether c is the zero value.
 func (c Color) IsZero() bool { return c == Color{} }
 
-// Named colors callers can use without constructing one manually. Choose
-// readable defaults; users can pick custom RGBA when they need to.
+// Fixed-RGBA named colors. These don't adapt to dark / light mode; for
+// hierarchy and accent colors that should adapt, use the semantic
+// constants (LabelPrimary etc.) below.
 var (
 	Red    = Color{R: 220, G: 50, B: 50, A: 255}
 	Green  = Color{R: 30, G: 160, B: 60, A: 255}
@@ -24,17 +33,46 @@ var (
 	Gray   = Color{R: 128, G: 128, B: 128, A: 255}
 )
 
+// Semantic colors map onto AppKit dynamic NSColors and re-resolve per
+// appearance at draw time. Use these for text hierarchy and accents
+// that should adapt across light and dark mode.
+var (
+	LabelPrimary    = Color{Semantic: "labelColor"}           // default text
+	LabelSecondary  = Color{Semantic: "secondaryLabelColor"}  // less prominent
+	LabelTertiary   = Color{Semantic: "tertiaryLabelColor"}   // metadata / fine print
+	LabelQuaternary = Color{Semantic: "quaternaryLabelColor"} // very faint, e.g. spoiler veil
+
+	SystemRed    = Color{Semantic: "systemRedColor"}
+	SystemGreen  = Color{Semantic: "systemGreenColor"}
+	SystemYellow = Color{Semantic: "systemYellowColor"}
+	SystemBlue   = Color{Semantic: "systemBlueColor"}
+	SystemOrange = Color{Semantic: "systemOrangeColor"}
+	SystemPurple = Color{Semantic: "systemPurpleColor"}
+	SystemPink   = Color{Semantic: "systemPinkColor"}
+	SystemGray   = Color{Semantic: "systemGrayColor"}
+	SystemBrown  = Color{Semantic: "systemBrownColor"}
+	SystemTeal   = Color{Semantic: "systemTealColor"}
+	SystemIndigo = Color{Semantic: "systemIndigoColor"}
+	SystemMint   = Color{Semantic: "systemMintColor"}
+	SystemCyan   = Color{Semantic: "systemCyanColor"}
+)
+
 // TextRun is one segment of a styled menu-item title. Multiple runs are
 // concatenated to form the full title with per-segment styling — see
 // Regular.Runs. The zero value of each style field means "inherit" so a
 // run can change just one attribute (e.g. only Color) without disturbing
 // the others.
+//
+// When Badge is true the run renders as a filled, rounded pill rather
+// than text: Color becomes the fill color and Text appears in white-on-
+// fill at small size. Useful for "LIVE" / "NEW" pills next to a row.
 type TextRun struct {
 	Text       string
 	Color      Color      // zero = system default
 	FontSize   int        // 0 = inherit from item
 	FontWeight FontWeight // 0 = default
 	Monospaced bool       // true = system monospace font
+	Badge      bool       // true = render as rounded-pill badge
 }
 
 // FontWeight represents the weight of the font

--- a/menuet.go
+++ b/menuet.go
@@ -126,7 +126,11 @@ func (a *Application) HideStartup() {
 // MenuState represents the title and drop down,
 type MenuState struct {
 	Title string
-	Image string // // In Resources dir or URL, should have height 22
+	// Runs, when non-empty, overrides Title with per-segment styled text
+	// — the same TextRun shape used by Regular.Runs. Useful for a status-
+	// item title that mixes weights, sizes, colors, or monospaced digits.
+	Runs  []TextRun
+	Image string // In Resources dir or URL, should have height 22
 }
 
 func (a *Application) sendState(state *MenuState) {

--- a/menuet.m
+++ b/menuet.m
@@ -243,8 +243,39 @@ static NSEventModifierFlags MenuetModifierMaskFromCarbon(uint32_t carbon) {
 // A run's zero-value Color/FontSize/FontWeight means "inherit from the
 // item-level value" so callers can change just one attribute per run
 // without re-specifying the rest.
+// Map a Color.Semantic string to an AppKit dynamic NSColor that re-
+// resolves per appearance. Returns nil for unknown names so callers
+// fall through to the RGBA path.
+static NSColor *MenuetColorFromSemantic(NSString *name) {
+	if (name.length == 0) return nil;
+	if ([name isEqualToString:@"labelColor"])           return [NSColor labelColor];
+	if ([name isEqualToString:@"secondaryLabelColor"])  return [NSColor secondaryLabelColor];
+	if ([name isEqualToString:@"tertiaryLabelColor"])   return [NSColor tertiaryLabelColor];
+	if ([name isEqualToString:@"quaternaryLabelColor"]) return [NSColor quaternaryLabelColor];
+	if ([name isEqualToString:@"systemRedColor"])       return [NSColor systemRedColor];
+	if ([name isEqualToString:@"systemGreenColor"])     return [NSColor systemGreenColor];
+	if ([name isEqualToString:@"systemYellowColor"])    return [NSColor systemYellowColor];
+	if ([name isEqualToString:@"systemBlueColor"])      return [NSColor systemBlueColor];
+	if ([name isEqualToString:@"systemOrangeColor"])    return [NSColor systemOrangeColor];
+	if ([name isEqualToString:@"systemPurpleColor"])    return [NSColor systemPurpleColor];
+	if ([name isEqualToString:@"systemPinkColor"])      return [NSColor systemPinkColor];
+	if ([name isEqualToString:@"systemGrayColor"])      return [NSColor systemGrayColor];
+	if ([name isEqualToString:@"systemBrownColor"])     return [NSColor systemBrownColor];
+	if ([name isEqualToString:@"systemTealColor"])      return [NSColor systemTealColor];
+	if ([name isEqualToString:@"systemIndigoColor"])    return [NSColor systemIndigoColor];
+	if ([name isEqualToString:@"systemMintColor"]) {
+		if (@available(macOS 12.0, *)) return [NSColor systemMintColor];
+	}
+	if ([name isEqualToString:@"systemCyanColor"]) {
+		if (@available(macOS 12.0, *)) return [NSColor systemCyanColor];
+	}
+	return nil;
+}
+
 static NSColor *MenuetColorFromDict(NSDictionary *dict) {
 	if (!dict) return nil;
+	NSColor *semantic = MenuetColorFromSemantic(dict[@"Semantic"]);
+	if (semantic) return semantic;
 	NSNumber *r = dict[@"R"];
 	NSNumber *g = dict[@"G"];
 	NSNumber *b = dict[@"B"];
@@ -257,6 +288,33 @@ static NSColor *MenuetColorFromDict(NSDictionary *dict) {
 	                       green:g.floatValue / 255.0
 	                        blue:b.floatValue / 255.0
 	                       alpha:a.floatValue / 255.0];
+}
+
+// Pre-render a rounded-pill badge for a TextRun{Badge: true}: rounded
+// rectangle filled with fillColor, with the text drawn in white-on-fill
+// at 9pt bold uppercase. The image's size matches the badge geometry
+// from the design handoff (h14, padX5, radius7).
+static NSImage *MenuetBadgeImage(NSString *text, NSColor *fillColor) {
+	NSString *upper = [text uppercaseString];
+	NSDictionary *attrs = @{
+	    NSFontAttributeName: [NSFont boldSystemFontOfSize:9],
+	    NSForegroundColorAttributeName: [NSColor whiteColor],
+	    NSKernAttributeName: @(0.4),
+	};
+	NSSize textSize = [upper sizeWithAttributes:attrs];
+	CGFloat width = ceil(textSize.width) + 10; // 5pt padding each side
+	CGFloat height = 14;
+	NSImage *img = [[NSImage alloc] initWithSize:NSMakeSize(width, height)];
+	[img lockFocus];
+	NSBezierPath *path = [NSBezierPath bezierPathWithRoundedRect:NSMakeRect(0, 0, width, height)
+	                                                    xRadius:7
+	                                                    yRadius:7];
+	[(fillColor ?: [NSColor tertiaryLabelColor]) setFill];
+	[path fill];
+	[upper drawAtPoint:NSMakePoint(5, (height - textSize.height) / 2.0)
+	    withAttributes:attrs];
+	[img unlockFocus];
+	return img;
 }
 
 static NSFont *MenuetFont(CGFloat size, CGFloat weight, BOOL mono) {
@@ -285,6 +343,15 @@ static NSAttributedString *MenuetBuildAttributedTitle(NSString *text,
 		if (![run isKindOfClass:[NSDictionary class]]) continue;
 		NSString *segText = run[@"Text"] ?: @"";
 		if (segText.length == 0) continue;
+		// Badge: render as a rounded-pill image attachment in line.
+		if ([run[@"Badge"] boolValue]) {
+			NSColor *fill = MenuetColorFromDict(run[@"Color"]) ?: [NSColor tertiaryLabelColor];
+			NSTextAttachment *attachment = [NSTextAttachment new];
+			attachment.image = MenuetBadgeImage(segText, fill);
+			[result appendAttributedString:
+			    [NSAttributedString attributedStringWithAttachment:attachment]];
+			continue;
+		}
 		NSNumber *fsNum = run[@"FontSize"];
 		NSNumber *fwNum = run[@"FontWeight"];
 		BOOL runMono = [run[@"Monospaced"] boolValue] || itemMono;
@@ -298,6 +365,19 @@ static NSAttributedString *MenuetBuildAttributedTitle(NSString *text,
 		                                                              attributes:attrs]];
 	}
 	return result;
+}
+
+// Concatenate just the text content of a Runs array — useful when the
+// platform's native subtitle slot only accepts a plain string.
+static NSString *MenuetPlainTextFromRuns(NSArray *runs) {
+	if (![runs isKindOfClass:[NSArray class]] || runs.count == 0) return nil;
+	NSMutableString *out = [NSMutableString new];
+	for (NSDictionary *run in runs) {
+		if (![run isKindOfClass:[NSDictionary class]]) continue;
+		NSString *t = run[@"Text"] ?: @"";
+		[out appendString:t];
+	}
+	return out;
 }
 
 @implementation MenuetMenu
@@ -389,6 +469,14 @@ static NSAttributedString *MenuetBuildAttributedTitle(NSString *text,
 		item.attributedTitle = MenuetBuildAttributedTitle(
 		    text, runs, fontSize.floatValue, fontWeight.floatValue,
 		    itemColor, itemMono);
+		// Two-line layout (macOS 14+ only). On older systems
+		// NSMenuItem.subtitle doesn't exist and the second line is
+		// silently dropped — see Subtitle's doc comment.
+		NSArray *subtitleRuns = dict[@"Subtitle"];
+		if (@available(macOS 14.0, *)) {
+			NSString *subtitleText = MenuetPlainTextFromRuns(subtitleRuns);
+			item.subtitle = subtitleText ?: @"";
+		}
 		// Shortcut display in the menu (⌘N etc.). The global hotkey
 		// registration happens Go-side in buildInternalItem.
 		NSDictionary *shortcut = dict[@"Shortcut"];
@@ -776,13 +864,17 @@ void setState(const char *jsonString) {
 	                       options:0
 	                       error:nil];
 	dispatch_async(dispatch_get_main_queue(), ^{
-		_statusItem.button.attributedTitle = [[NSAttributedString alloc]
-		                                      initWithString:state[@"Title"]
-		                                      attributes:@{
-		                                              NSFontAttributeName :
-		                                              [NSFont monospacedDigitSystemFontOfSize:14
-		                                               weight:NSFontWeightRegular]
-		}];
+		// Build the title via the same runs→attributed-string path the
+		// dropdown rows use. When Runs is empty, MenuetBuildAttributedTitle
+		// falls back to plain Title, preserving the pre-runs behavior.
+		NSString *title = state[@"Title"] ?: @"";
+		NSArray *titleRuns = state[@"Runs"];
+		_statusItem.button.attributedTitle = MenuetBuildAttributedTitle(
+		    title, titleRuns,
+		    /*itemFontSize=*/14,
+		    /*itemFontWeight=*/NSFontWeightRegular,
+		    /*itemColorDict=*/nil,
+		    /*itemMono=*/NO);
 		NSString *imageName = state[@"Image"];
 		NSImage *image = [NSImage imageFromName:imageName withHeight:22];
 		_statusItem.button.image = image;

--- a/menuitem.go
+++ b/menuitem.go
@@ -38,6 +38,13 @@ type Regular struct {
 	// wins; subsequent registrations are silently ignored.
 	Shortcut *Shortcut
 
+	// Subtitle, when non-empty, renders as a dimmer second line below the
+	// main title — Apple's native NSMenuItem.subtitle on macOS 14+. The
+	// runs' per-segment colors aren't honored on this path (NSMenuItem.subtitle
+	// is a plain string property); only the concatenated text appears in
+	// the system's standard subtitle styling.
+	Subtitle []TextRun
+
 	Clicked  func()
 	Children func() []MenuItem
 }
@@ -81,6 +88,7 @@ type internalItem struct {
 	Type        string
 	Text        string
 	Runs        []TextRun `json:",omitempty"`
+	Subtitle    []TextRun `json:",omitempty"`
 	Image       string
 	FontSize    int
 	FontWeight  FontWeight
@@ -102,6 +110,7 @@ func buildInternalItem(item MenuItem, unique, parentUnique string) internalItem 
 	case Regular:
 		out.Text = v.Text
 		out.Runs = v.Runs
+		out.Subtitle = v.Subtitle
 		out.Image = v.Image
 		out.FontSize = v.FontSize
 		out.FontWeight = v.FontWeight

--- a/sportsbar_test.go
+++ b/sportsbar_test.go
@@ -1,0 +1,109 @@
+package menuet
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Color.Semantic tests
+
+func TestSemanticColorIsNotZero(t *testing.T) {
+	if LabelPrimary.IsZero() {
+		t.Error("LabelPrimary should not be IsZero")
+	}
+	if SystemRed.IsZero() {
+		t.Error("SystemRed should not be IsZero")
+	}
+}
+
+func TestSemanticColorSerializesSemanticField(t *testing.T) {
+	b, _ := json.Marshal(LabelSecondary)
+	got := string(b)
+	if !strings.Contains(got, `"Semantic":"secondaryLabelColor"`) {
+		t.Errorf("semantic field missing\nfull: %s", got)
+	}
+	// And the RGBA fields should be zero/omitted-like
+	if strings.Contains(got, `"R":255`) {
+		t.Errorf("semantic color shouldn't leak R\nfull: %s", got)
+	}
+}
+
+func TestSemanticColorRoundTrip(t *testing.T) {
+	var c Color
+	if err := json.Unmarshal([]byte(`{"Semantic":"systemRedColor"}`), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if c.Semantic != "systemRedColor" {
+		t.Errorf("Semantic round-trip failed: got %q", c.Semantic)
+	}
+}
+
+// MenuState.Runs tests
+
+func TestMenuStateRunsSerialize(t *testing.T) {
+	s := &MenuState{
+		Title: "fallback",
+		Runs: []TextRun{
+			{Text: "GSW", FontWeight: WeightSemibold},
+			{Text: " 7:30pm", Color: LabelSecondary},
+		},
+	}
+	b, _ := json.Marshal(s)
+	got := string(b)
+	for _, want := range []string{
+		`"Title":"fallback"`,
+		`"Runs":[`,
+		`"Text":"GSW"`,
+		`"FontWeight":0.3`,
+		`"Semantic":"secondaryLabelColor"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("MenuState JSON missing %q\nfull: %s", want, got)
+		}
+	}
+}
+
+// Regular.Subtitle tests
+
+func TestRegularSubtitleSerializes(t *testing.T) {
+	item := buildInternalItem(
+		Regular{
+			Text: "GSW 71 – 68 MIN",
+			Subtitle: []TextRun{
+				{Text: "NBA · Q3 5:42"},
+			},
+		},
+		"u", "p",
+	)
+	b, _ := json.Marshal(item)
+	got := string(b)
+	if !strings.Contains(got, `"Subtitle":[`) {
+		t.Errorf("Subtitle missing\nfull: %s", got)
+	}
+	if !strings.Contains(got, `"Text":"NBA · Q3 5:42"`) {
+		t.Errorf("subtitle text missing\nfull: %s", got)
+	}
+}
+
+func TestRegularWithoutSubtitleOmitsKey(t *testing.T) {
+	item := buildInternalItem(Regular{Text: "hello"}, "u", "p")
+	b, _ := json.Marshal(item)
+	if strings.Contains(string(b), `"Subtitle":`) {
+		t.Errorf("empty Subtitle should be omitted; got: %s", b)
+	}
+}
+
+// TextRun.Badge tests
+
+func TestBadgeRunSerializes(t *testing.T) {
+	r := TextRun{Text: "LIVE", Color: SystemRed, Badge: true}
+	b, _ := json.Marshal(r)
+	got := string(b)
+	if !strings.Contains(got, `"Badge":true`) {
+		t.Errorf("Badge field missing\nfull: %s", got)
+	}
+	if !strings.Contains(got, `"Semantic":"systemRedColor"`) {
+		t.Errorf("Badge color should still serialize\nfull: %s", got)
+	}
+}

--- a/startup.go
+++ b/startup.go
@@ -52,6 +52,13 @@ func (a *Application) getStartupPath() string {
 }
 
 func (a *Application) runningAtStartup() bool {
+	// If the consumer hasn't even set a Label, they haven't opted into
+	// startup-item management. Return false rather than reporting on the
+	// host process's general SMAppService status (the test binary on a
+	// developer's machine may otherwise see a stale "registered" answer).
+	if a.Label == "" {
+		return false
+	}
 	// SMAppService is the modern (macOS 13+) backend and what users
 	// expect: the System Settings → Login Items panel reflects it. Check
 	// it first; fall back to looking for our LaunchAgent plist.


### PR DESCRIPTION
Implements the four required capabilities from the sportsbar design handoff (\`design_handoff_menuet_richtext\`).

## What's new

### 1. Status-item runs

\`MenuState\` gains \`Runs []TextRun\`. Use the same per-segment styling on the menubar title that already worked on rows.

\`\`\`go
menuet.App().SetMenuState(&menuet.MenuState{
    Runs: []menuet.TextRun{
        {Text: \"● \", Color: menuet.SystemRed},
        {Text: \"GSW \", FontWeight: menuet.WeightSemibold},
        {Text: \"71\", FontWeight: menuet.WeightBold, Monospaced: true},
        {Text: \"–68 MIN\", Color: menuet.LabelSecondary, Monospaced: true},
    },
})
\`\`\`

### 2. Appearance-adaptive semantic colors

\`Color\` gains a \`Semantic\` field. When set, the ObjC bridge resolves to an AppKit dynamic NSColor that re-resolves per appearance at draw time:

\`\`\`go
{Text: \"failed\", Color: menuet.SystemRed}        // adapts in dark mode
{Text: \"meta\",   Color: menuet.LabelTertiary}    // hierarchy color
\`\`\`

Full constant set: \`LabelPrimary/Secondary/Tertiary/Quaternary\` and \`SystemRed/Green/Yellow/Blue/Orange/Purple/Pink/Gray/Brown/Teal/Indigo/Mint/Cyan\`. The fixed-RGBA Red/Green/etc. constants from earlier releases stay as-is for backward compatibility.

### 3. Two-line items

\`Regular\` gains \`Subtitle []TextRun\`. On macOS 14+ this uses Apple's native \`NSMenuItem.subtitle\` (dimmer second line). On older systems the subtitle is silently dropped.

\`\`\`go
menuet.Regular{
    Runs: []menuet.TextRun{ /* primary line */ },
    Subtitle: []menuet.TextRun{
        {Text: \"NBA · Q3 5:42\"},
    },
}
\`\`\`

### 4. Badge runs

\`TextRun\` gains \`Badge bool\`. When true, the run renders as a rounded pill — \`Color\` becomes the fill, text is white-on-fill at 9pt bold uppercase. Geometry per spec: h14, padX5, radius7. Implemented via \`NSTextAttachment\` with a pre-rendered \`NSImage\`.

\`\`\`go
{Text: \"LIVE\", Color: menuet.SystemRed, Badge: true}
\`\`\`

## Backward compatibility

All four additions are additive. Existing code unchanged. Tests cover semantic color JSON shape and round-trip, MenuState Runs, Regular.Subtitle, and Badge field serialization.

cmd/catalog gains 4 new \"Rich text\" demo items + a \"Runs in the title (live score)\" entry under Change Title to exercise the status item runs path.

## Misc

Tightens \`runningAtStartup\` so SMAppService consultation is gated on \`Application.Label\` being set — test binaries on a developer machine no longer pick up the host's unrelated SMAppService status (fixes a flake introduced in v2.6.0).