### PR TITLE
v2.8.0: Underline, Strikethrough, Background, Shadow on TextRun

### DIFF
--- a/cmd/catalog/catalog.go
+++ b/cmd/catalog/catalog.go
@@ -161,6 +161,30 @@ func richTextDemo() []menuet.MenuItem {
 	return []menuet.MenuItem{
 		menuet.Regular{
 			Runs: []menuet.TextRun{
+				{Text: "🏆 ", FontSize: 16},
+				{
+					Text:       "LAL WINS",
+					FontWeight: menuet.WeightHeavy,
+					FontSize:   15,
+					Color:      menuet.Color{R: 230, G: 180, B: 30, A: 255},
+					Shadow: &menuet.Shadow{
+						Color: menuet.Color{R: 255, G: 220, B: 80, A: 220},
+						Blur:  8,
+					},
+				},
+			},
+		},
+		menuet.Regular{
+			Runs: []menuet.TextRun{
+				{Text: "Underline", Underline: true},
+				{Text: "  ·  "},
+				{Text: "Strikethrough", Strikethrough: true, Color: menuet.LabelSecondary},
+				{Text: "  ·  "},
+				{Text: " marker ", Background: menuet.Color{R: 255, G: 240, B: 130, A: 255}},
+			},
+		},
+		menuet.Regular{
+			Runs: []menuet.TextRun{
 				{Text: "Semantic ", Color: menuet.LabelPrimary},
 				{Text: "colors ", Color: menuet.LabelSecondary},
 				{Text: "adapt ", Color: menuet.LabelTertiary},

--- a/emphasis_test.go
+++ b/emphasis_test.go
@@ -1,0 +1,73 @@
+package menuet
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestUnderlineRunSerializes(t *testing.T) {
+	r := TextRun{Text: "winner", Underline: true}
+	b, _ := json.Marshal(r)
+	if !strings.Contains(string(b), `"Underline":true`) {
+		t.Errorf("Underline missing: %s", b)
+	}
+}
+
+func TestStrikethroughRunSerializes(t *testing.T) {
+	r := TextRun{Text: "eliminated", Strikethrough: true}
+	b, _ := json.Marshal(r)
+	if !strings.Contains(string(b), `"Strikethrough":true`) {
+		t.Errorf("Strikethrough missing: %s", b)
+	}
+}
+
+func TestBackgroundRunSerializes(t *testing.T) {
+	r := TextRun{Text: "highlight", Background: Yellow}
+	b, _ := json.Marshal(r)
+	got := string(b)
+	// Background is its own Color key in the JSON, not Color.
+	if !strings.Contains(got, `"Background":{`) {
+		t.Errorf("Background missing: %s", got)
+	}
+	if !strings.Contains(got, `"R":200`) {
+		t.Errorf("Background RGBA missing: %s", got)
+	}
+}
+
+func TestShadowRunSerializes(t *testing.T) {
+	r := TextRun{
+		Text: "trophy",
+		Shadow: &Shadow{
+			Color: Yellow,
+			Blur:  8,
+		},
+	}
+	b, _ := json.Marshal(r)
+	got := string(b)
+	if !strings.Contains(got, `"Shadow":{`) {
+		t.Errorf("Shadow missing: %s", got)
+	}
+	if !strings.Contains(got, `"Blur":8`) {
+		t.Errorf("Blur missing: %s", got)
+	}
+	if !strings.Contains(got, `"Semantic":"systemYellowColor"`) && !strings.Contains(got, `"R":200,"G":160`) {
+		t.Errorf("Shadow Color missing: %s", got)
+	}
+}
+
+func TestPlainRunOmitsEmphasisFields(t *testing.T) {
+	// Without using the omitempty pattern in this PR (kept additive for
+	// schema stability), a plain run still serializes its boolean zeros.
+	// What matters is the deserialized side ignores them — verify a plain
+	// run round-trips with no emphasis flags set.
+	r := TextRun{Text: "hi"}
+	b, _ := json.Marshal(r)
+	var got TextRun
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Underline || got.Strikethrough || got.Shadow != nil || !got.Background.IsZero() {
+		t.Errorf("plain run should have no emphasis fields set, got %+v", got)
+	}
+}

--- a/formatting.go
+++ b/formatting.go
@@ -66,13 +66,32 @@ var (
 // When Badge is true the run renders as a filled, rounded pill rather
 // than text: Color becomes the fill color and Text appears in white-on-
 // fill at small size. Useful for "LIVE" / "NEW" pills next to a row.
+//
+// Underline, Strikethrough, Background, and Shadow are common emphasis
+// attributes — useful for marking winners/losers, "marker-pen" style
+// highlights, and trophy-glow celebrations.
 type TextRun struct {
-	Text       string
-	Color      Color      // zero = system default
-	FontSize   int        // 0 = inherit from item
-	FontWeight FontWeight // 0 = default
-	Monospaced bool       // true = system monospace font
-	Badge      bool       // true = render as rounded-pill badge
+	Text          string
+	Color         Color      // zero = system default
+	FontSize      int        // 0 = inherit from item
+	FontWeight    FontWeight // 0 = default
+	Monospaced    bool       // true = system monospace font
+	Badge         bool       // true = render as rounded-pill badge
+	Underline     bool       // single underline in the run's foreground color
+	Strikethrough bool       // single strike through the text
+	Background    Color      // zero = none; non-zero = colored highlight behind text
+	Shadow        *Shadow    // nil = no shadow; set for a drop-shadow or glow
+}
+
+// Shadow is a drop-shadow or glow rendered behind a TextRun. Set Blur
+// alone (with the default zero offset) for a glow effect; set OffsetX
+// and OffsetY for a directional drop shadow. Color of zero defaults to
+// translucent black at draw time.
+type Shadow struct {
+	Color   Color
+	Blur    float64 // blur radius in points; 0 = sharp
+	OffsetX float64 // horizontal offset in points
+	OffsetY float64 // vertical offset in points (AppKit: positive = up)
 }
 
 // FontWeight represents the weight of the font

--- a/menuet.m
+++ b/menuet.m
@@ -361,6 +361,24 @@ static NSAttributedString *MenuetBuildAttributedTitle(NSString *text,
 		NSMutableDictionary *attrs = [NSMutableDictionary new];
 		attrs[NSFontAttributeName] = MenuetFont(fs, fw, runMono);
 		if (runColor) attrs[NSForegroundColorAttributeName] = runColor;
+		if ([run[@"Underline"] boolValue]) {
+			attrs[NSUnderlineStyleAttributeName] = @(NSUnderlineStyleSingle);
+		}
+		if ([run[@"Strikethrough"] boolValue]) {
+			attrs[NSStrikethroughStyleAttributeName] = @(NSUnderlineStyleSingle);
+		}
+		NSColor *bg = MenuetColorFromDict(run[@"Background"]);
+		if (bg) attrs[NSBackgroundColorAttributeName] = bg;
+		NSDictionary *shadowDict = run[@"Shadow"];
+		if ([shadowDict isKindOfClass:[NSDictionary class]]) {
+			NSShadow *shadow = [NSShadow new];
+			NSColor *shadowColor = MenuetColorFromDict(shadowDict[@"Color"]);
+			shadow.shadowColor = shadowColor ?: [NSColor colorWithWhite:0 alpha:0.6];
+			shadow.shadowBlurRadius = [shadowDict[@"Blur"] doubleValue];
+			shadow.shadowOffset = NSMakeSize([shadowDict[@"OffsetX"] doubleValue],
+			                                  [shadowDict[@"OffsetY"] doubleValue]);
+			attrs[NSShadowAttributeName] = shadow;
+		}
 		[result appendAttributedString:[[NSAttributedString alloc] initWithString:segText
 		                                                              attributes:attrs]];
 	}


### PR DESCRIPTION
Four more attributed-string attributes for richer non-animated emphasis. Each is one NSAttributedString attribute under the hood — no new bridge, no private API.

\`\`\`go
type TextRun struct {
    // ...existing fields...
    Underline     bool
    Strikethrough bool
    Background    Color
    Shadow        *Shadow
}

type Shadow struct {
    Color   Color
    Blur    float64
    OffsetX float64
    OffsetY float64
}
\`\`\`

## Use cases

**Winner celebration (the trophy-glow case):**

\`\`\`go
menuet.Regular{
    Runs: []menuet.TextRun{
        {Text: \"🏆 \", FontSize: 16},
        {
            Text:       \"LAL WINS\",
            FontWeight: menuet.WeightHeavy,
            FontSize:   15,
            Color:      menuet.Color{R: 230, G: 180, B: 30, A: 255},
            Shadow: &menuet.Shadow{
                Color: menuet.Color{R: 255, G: 220, B: 80, A: 220},
                Blur:  8,
            },
        },
    },
}
\`\`\`

**Eliminated / loss:**
\`\`\`go
{Text: \"Cavaliers\", Strikethrough: true, Color: menuet.LabelSecondary}
\`\`\`

**Marker-pen highlight (different from Badge — text stays normal):**
\`\`\`go
{Text: \" tonight \", Background: menuet.Color{R: 255, G: 240, B: 130, A: 255}}
\`\`\`

## Verification

  - 5 new unit tests covering JSON shape for each field and round-trip of a plain run
  - cmd/catalog \"Rich text\" submenu gains two new rows: the trophy-glow LAL WINS celebration + a side-by-side Underline · Strikethrough · marker showcase
  - All existing tests still pass

Additive — no breaking changes.