### PR TITLE
v2.9.0: UnderlineColor + StrikethroughColor on TextRun

### DIFF
--- a/cmd/catalog/catalog.go
+++ b/cmd/catalog/catalog.go
@@ -185,6 +185,23 @@ func richTextDemo() []menuet.MenuItem {
 		},
 		menuet.Regular{
 			Runs: []menuet.TextRun{
+				{Text: "Underline color independent of text: "},
+				{
+					Text:           "misspelled",
+					Underline:      true,
+					UnderlineColor: menuet.SystemRed,
+				},
+				{Text: "  /  "},
+				{
+					Text:               "outdated",
+					Color:              menuet.LabelSecondary,
+					Strikethrough:      true,
+					StrikethroughColor: menuet.SystemRed,
+				},
+			},
+		},
+		menuet.Regular{
+			Runs: []menuet.TextRun{
 				{Text: "Semantic ", Color: menuet.LabelPrimary},
 				{Text: "colors ", Color: menuet.LabelSecondary},
 				{Text: "adapt ", Color: menuet.LabelTertiary},

--- a/emphasis_test.go
+++ b/emphasis_test.go
@@ -56,6 +56,45 @@ func TestShadowRunSerializes(t *testing.T) {
 	}
 }
 
+func TestUnderlineColorIndependent(t *testing.T) {
+	// Spell-checker style: gray text, red underline.
+	r := TextRun{
+		Text:           "misspelled",
+		Color:          Gray,
+		Underline:      true,
+		UnderlineColor: SystemRed,
+	}
+	b, _ := json.Marshal(r)
+	got := string(b)
+	if !strings.Contains(got, `"Underline":true`) {
+		t.Errorf("Underline missing: %s", got)
+	}
+	// UnderlineColor must serialize as its own Color object (not merged
+	// with the run's foreground) so the ObjC bridge sees it separately.
+	if !strings.Contains(got, `"UnderlineColor":`) ||
+		!strings.Contains(got, `"Semantic":"systemRedColor"`) {
+		t.Errorf("UnderlineColor missing or wrong shape: %s", got)
+	}
+}
+
+func TestStrikethroughColorIndependent(t *testing.T) {
+	r := TextRun{
+		Text:               "outdated",
+		Color:              LabelSecondary,
+		Strikethrough:      true,
+		StrikethroughColor: SystemRed,
+	}
+	b, _ := json.Marshal(r)
+	got := string(b)
+	if !strings.Contains(got, `"Strikethrough":true`) {
+		t.Errorf("Strikethrough missing: %s", got)
+	}
+	if !strings.Contains(got, `"StrikethroughColor":`) ||
+		!strings.Contains(got, `"Semantic":"systemRedColor"`) {
+		t.Errorf("StrikethroughColor missing or wrong shape: %s", got)
+	}
+}
+
 func TestPlainRunOmitsEmphasisFields(t *testing.T) {
 	// Without using the omitempty pattern in this PR (kept additive for
 	// schema stability), a plain run still serializes its boolean zeros.

--- a/formatting.go
+++ b/formatting.go
@@ -71,16 +71,25 @@ var (
 // attributes — useful for marking winners/losers, "marker-pen" style
 // highlights, and trophy-glow celebrations.
 type TextRun struct {
-	Text          string
-	Color         Color      // zero = system default
-	FontSize      int        // 0 = inherit from item
-	FontWeight    FontWeight // 0 = default
-	Monospaced    bool       // true = system monospace font
-	Badge         bool       // true = render as rounded-pill badge
-	Underline     bool       // single underline in the run's foreground color
-	Strikethrough bool       // single strike through the text
-	Background    Color      // zero = none; non-zero = colored highlight behind text
-	Shadow        *Shadow    // nil = no shadow; set for a drop-shadow or glow
+	Text       string
+	Color      Color      // zero = system default
+	FontSize   int        // 0 = inherit from item
+	FontWeight FontWeight // 0 = default
+	Monospaced bool       // true = system monospace font
+	Badge      bool       // true = render as rounded-pill badge
+
+	// Underline draws a single underline. By default it uses the run's
+	// foreground Color; set UnderlineColor for an independent color.
+	Underline      bool
+	UnderlineColor Color // zero = follow foreground
+
+	// Strikethrough draws a single strike. By default it uses the run's
+	// foreground Color; set StrikethroughColor for an independent color.
+	Strikethrough      bool
+	StrikethroughColor Color // zero = follow foreground
+
+	Background Color   // zero = none; non-zero = colored highlight behind text
+	Shadow     *Shadow // nil = no shadow; set for a drop-shadow or glow
 }
 
 // Shadow is a drop-shadow or glow rendered behind a TextRun. Set Blur

--- a/menuet.m
+++ b/menuet.m
@@ -363,9 +363,13 @@ static NSAttributedString *MenuetBuildAttributedTitle(NSString *text,
 		if (runColor) attrs[NSForegroundColorAttributeName] = runColor;
 		if ([run[@"Underline"] boolValue]) {
 			attrs[NSUnderlineStyleAttributeName] = @(NSUnderlineStyleSingle);
+			NSColor *uc = MenuetColorFromDict(run[@"UnderlineColor"]);
+			if (uc) attrs[NSUnderlineColorAttributeName] = uc;
 		}
 		if ([run[@"Strikethrough"] boolValue]) {
 			attrs[NSStrikethroughStyleAttributeName] = @(NSUnderlineStyleSingle);
+			NSColor *sc = MenuetColorFromDict(run[@"StrikethroughColor"]);
+			if (sc) attrs[NSStrikethroughColorAttributeName] = sc;
 		}
 		NSColor *bg = MenuetColorFromDict(run[@"Background"]);
 		if (bg) attrs[NSBackgroundColorAttributeName] = bg;


### PR DESCRIPTION
Follow-up to v2.8.0 — exposes the NSAttributedString attributes for independent underline and strike colors.

\`\`\`go
type TextRun struct {
    // ...
    Underline      bool
    UnderlineColor Color // NEW — zero = follow foreground (v2.8 behavior)

    Strikethrough      bool
    StrikethroughColor Color // NEW — zero = follow foreground
}
\`\`\`

## Use case

Spell-checker style emphasis, eliminated picks with a red strike on muted text, etc:

\`\`\`go
{Text: \"misspelled\", Underline: true, UnderlineColor: menuet.SystemRed}
{Text: \"outdated\", Color: menuet.LabelSecondary, Strikethrough: true, StrikethroughColor: menuet.SystemRed}
\`\`\`

Both new fields are \`Color\` so they inherit the same fixed-RGBA vs semantic-NSColor handling as the run's foreground. Zero = follow foreground; v2.8 behavior preserved.

## Verification

  - 2 new unit tests for JSON shape of independent-color fields
  - cmd/catalog Rich-text submenu gains a row showing both side by side
  - All existing emphasis tests still pass