### PR TITLE
Snapshot mode + pure-Go HTML renderer for menu mockups

### DIFF
--- a/html/render.go
+++ b/html/render.go
@@ -1,0 +1,241 @@
+// Package html renders a menuet.Snapshot to a self-contained HTML
+// fragment that approximates how the menu looks in the macOS menu bar.
+//
+// The renderer is intentionally a pure data → HTML transform: it never
+// runs code from the snapshot, never fetches remote resources, and only
+// emits a fixed set of tags and CSS properties. That makes it safe to
+// run on snapshots from untrusted third-party apps — anything outside
+// the known schema is either ignored or rendered as escaped text.
+//
+// Output shape: a single <div class="menumock-…"> tree with inline styles
+// using a fixed set of CSS custom properties (--bar-bg, --panel-bg,
+// --text, etc.) set by the caller. The default theme is light; pass
+// Options{Theme: ThemeDark} for dark.
+package html
+
+import (
+	"fmt"
+	stdhtml "html"
+	"strings"
+
+	"github.com/caseymrm/menuet/v2"
+)
+
+// Theme picks the color palette. Both themes match the look from the
+// menuet.app design — translucent panel, subtle border, text hierarchy.
+type Theme int
+
+const (
+	ThemeLight Theme = iota
+	ThemeDark
+)
+
+// Options tweaks rendering. Zero value renders a light-theme mockup.
+type Options struct {
+	Theme Theme
+
+	// AccentHex overrides the system accent color used for selection
+	// highlights and the menu-bar title pill (when the snapshot's
+	// State.Runs uses the accent semantic color). Empty falls back to
+	// the theme default (#007aff light / #0a84ff dark). Must be a
+	// 7-char "#rrggbb" string; other values are dropped.
+	AccentHex string
+}
+
+// Render produces an HTML fragment for the snapshot using the given
+// options. The output is safe to inline into a larger page: it brings
+// its own CSS-variable scope and only emits whitelisted tags/attrs/
+// CSS properties.
+//
+// If snap.Schema is not the version this renderer was built for, Render
+// returns an HTML comment noting the mismatch and the rest of the snap
+// is still rendered best-effort. Future schema bumps will gate stricter
+// behavior off the version string.
+func Render(snap menuet.Snapshot, opts Options) string {
+	var b strings.Builder
+	b.WriteString(`<div class="menumock" style="`)
+	b.WriteString(themeVars(opts))
+	b.WriteString(`">`)
+	if snap.Schema != "" && snap.Schema != menuet.SnapshotSchema {
+		fmt.Fprintf(&b, `<!-- menuet/html: unknown schema %q (expected %q) -->`,
+			snap.Schema, menuet.SnapshotSchema)
+	}
+	b.WriteString(`<div style="font-family: -apple-system, BlinkMacSystemFont, system-ui, 'SF Pro Text', sans-serif; width: 332px; display: flex; flex-direction: column; align-items: flex-end; gap: 7px; -webkit-font-smoothing: antialiased;">`)
+	renderBar(&b, snap.State)
+	renderPanel(&b, snap.Items)
+	b.WriteString(`</div></div>`)
+	return b.String()
+}
+
+func themeVars(opts Options) string {
+	accent := opts.AccentHex
+	if !isHexColor(accent) {
+		accent = ""
+	}
+	if opts.Theme == ThemeDark {
+		if accent == "" {
+			accent = "#0a84ff"
+		}
+		return joinVars(map[string]string{
+			"--bar-bg":       "rgba(28,28,30,0.46)",
+			"--bar-text":     "rgba(255,255,255,0.9)",
+			"--panel-bg":     "rgba(46,46,48,0.74)",
+			"--panel-border": "rgba(255,255,255,0.14)",
+			"--shadow":       "0 20px 54px rgba(0,0,0,0.55), 0 3px 12px rgba(0,0,0,0.4)",
+			"--text":         "rgba(255,255,255,0.92)",
+			"--text-2":       "rgba(255,255,255,0.52)",
+			"--text-3":       "rgba(255,255,255,0.36)",
+			"--sep":          "rgba(255,255,255,0.12)",
+			"--field-bg":     "rgba(255,255,255,0.10)",
+			"--hover":        "rgba(255,255,255,0.10)",
+			"--accent":       accent,
+			"--live":         "#ff453a",
+		})
+	}
+	if accent == "" {
+		accent = "#007aff"
+	}
+	return joinVars(map[string]string{
+		"--bar-bg":       "rgba(255,255,255,0.42)",
+		"--bar-text":     "rgba(0,0,0,0.82)",
+		"--panel-bg":     "rgba(249,249,250,0.78)",
+		"--panel-border": "rgba(0,0,0,0.10)",
+		"--shadow":       "0 16px 44px rgba(0,0,0,0.22), 0 3px 10px rgba(0,0,0,0.10)",
+		"--text":         "rgba(0,0,0,0.86)",
+		"--text-2":       "rgba(0,0,0,0.48)",
+		"--text-3":       "rgba(0,0,0,0.34)",
+		"--sep":          "rgba(0,0,0,0.10)",
+		"--field-bg":     "rgba(0,0,0,0.06)",
+		"--hover":        "rgba(0,0,0,0.07)",
+		"--accent":       accent,
+		"--live":         "#ff3b30",
+	})
+}
+
+func joinVars(m map[string]string) string {
+	// Stable order so identical inputs produce identical output.
+	keys := []string{
+		"--bar-bg", "--bar-text", "--panel-bg", "--panel-border", "--shadow",
+		"--text", "--text-2", "--text-3", "--sep", "--field-bg", "--hover",
+		"--accent", "--live",
+	}
+	var b strings.Builder
+	for _, k := range keys {
+		v, ok := m[k]
+		if !ok {
+			continue
+		}
+		b.WriteString(k)
+		b.WriteString(":")
+		b.WriteString(v)
+		b.WriteString(";")
+	}
+	return b.String()
+}
+
+func renderBar(b *strings.Builder, state *menuet.MenuState) {
+	b.WriteString(`<div style="width: 100%; display: flex; justify-content: flex-end; align-items: center; gap: 13px; padding: 0 8px; height: 24px; background: var(--bar-bg); -webkit-backdrop-filter: blur(20px) saturate(1.4); backdrop-filter: blur(20px) saturate(1.4); border-radius: 7px; color: var(--bar-text); font-size: 12.5px;">`)
+	if state != nil {
+		switch {
+		case len(state.Runs) > 0:
+			b.WriteString(`<div style="display: flex; align-items: center; gap: 4px; padding: 2px 7px; border-radius: 5px;">`)
+			for _, run := range state.Runs {
+				renderRun(b, run, true)
+			}
+			b.WriteString(`</div>`)
+		case state.Title != "":
+			b.WriteString(`<span style="font-weight: 600;">`)
+			b.WriteString(stdhtml.EscapeString(state.Title))
+			b.WriteString(`</span>`)
+		}
+	}
+	b.WriteString(`<span style="opacity: 0.6; font-variant-numeric: tabular-nums;">Wed 9:41 AM</span>`)
+	b.WriteString(`</div>`)
+}
+
+func renderPanel(b *strings.Builder, items []menuet.SnapshotItem) {
+	b.WriteString(`<div style="width: 320px; background: var(--panel-bg); -webkit-backdrop-filter: blur(34px) saturate(1.7); backdrop-filter: blur(34px) saturate(1.7); border: 0.5px solid var(--panel-border); border-radius: 11px; box-shadow: var(--shadow); padding: 5px 0;">`)
+	for _, item := range items {
+		renderItem(b, item)
+	}
+	b.WriteString(`</div>`)
+}
+
+func renderItem(b *strings.Builder, item menuet.SnapshotItem) {
+	switch item.Type {
+	case "separator":
+		b.WriteString(`<div style="height: 1px; background: var(--sep); margin: 5px 12px;"></div>`)
+	case "search":
+		b.WriteString(`<div style="margin: 1px 8px 5px; display: flex; align-items: center; gap: 6px; height: 27px; padding: 0 9px; background: var(--field-bg); border-radius: 6px; color: var(--text-3); font-size: 13px;">`)
+		b.WriteString(`<svg width="13" height="13" viewBox="0 0 13 13" fill="none" style="flex: none;"><circle cx="5.4" cy="5.4" r="3.9" stroke="currentColor" stroke-width="1.3"></circle><line x1="8.4" y1="8.4" x2="11.3" y2="11.3" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"></line></svg>`)
+		placeholder := item.Text
+		if placeholder == "" {
+			placeholder = "Search…"
+		}
+		b.WriteString(`<span>`)
+		b.WriteString(stdhtml.EscapeString(placeholder))
+		b.WriteString(`</span>`)
+		b.WriteString(`</div>`)
+		// Search results render below the field as ordinary rows.
+		for _, child := range item.Children {
+			renderItem(b, child)
+		}
+	default:
+		renderRegular(b, item)
+	}
+}
+
+func renderRegular(b *strings.Builder, item menuet.SnapshotItem) {
+	hasSubtitle := len(item.Subtitle) > 0
+	hasChildren := len(item.Children) > 0
+	if hasSubtitle {
+		b.WriteString(`<div class="menu-row" style="margin: 0 5px; padding: 5px 9px 6px 7px; border-radius: 6px; display: flex; align-items: flex-start; gap: 7px;">`)
+	} else {
+		b.WriteString(`<div class="menu-row" style="margin: 0 5px; padding: 0 9px 0 7px; min-height: 24px; border-radius: 6px; display: flex; align-items: center; gap: 7px; font-size: 13.5px; color: var(--text);">`)
+	}
+
+	// Checkmark gutter, always 14px wide so labels line up whether or not
+	// the row has State set.
+	if item.State {
+		b.WriteString(`<span style="width: 14px; flex: none; color: var(--accent); font-weight: 700; font-size: 12px;">✓</span>`)
+	} else {
+		b.WriteString(`<span style="width: 14px; flex: none;"></span>`)
+	}
+
+	if hasSubtitle {
+		b.WriteString(`<div style="flex: 1; min-width: 0;">`)
+		b.WriteString(`<div style="display: flex; align-items: center; gap: 6px; font-size: 13.5px; color: var(--text);">`)
+		renderLabel(b, item)
+		b.WriteString(`</div>`)
+		b.WriteString(`<div style="margin-top: 2px; font-size: 11px; color: var(--text-2);">`)
+		for _, run := range item.Subtitle {
+			renderRun(b, run, false)
+		}
+		b.WriteString(`</div>`)
+		b.WriteString(`</div>`)
+	} else {
+		b.WriteString(`<span style="flex: 1;">`)
+		renderLabel(b, item)
+		b.WriteString(`</span>`)
+		if item.Shortcut != nil {
+			b.WriteString(`<span style="color: var(--text-2); letter-spacing: 0.04em;">`)
+			b.WriteString(stdhtml.EscapeString(shortcutString(*item.Shortcut)))
+			b.WriteString(`</span>`)
+		} else if hasChildren {
+			b.WriteString(`<svg width="7" height="11" viewBox="0 0 7 11" fill="none" style="opacity: 0.5;"><polyline points="1,1 6,5.5 1,10" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"></polyline></svg>`)
+		}
+	}
+	b.WriteString(`</div>`)
+}
+
+// renderLabel emits either the Runs (per-segment styled) or the plain
+// Text. Plain text inherits the row's font color; Runs bring their own.
+func renderLabel(b *strings.Builder, item menuet.SnapshotItem) {
+	if len(item.Runs) > 0 {
+		for _, run := range item.Runs {
+			renderRun(b, run, false)
+		}
+		return
+	}
+	b.WriteString(stdhtml.EscapeString(item.Text))
+}

--- a/html/render_test.go
+++ b/html/render_test.go
@@ -1,0 +1,261 @@
+package html
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/caseymrm/menuet/v2"
+)
+
+// snap is a tiny helper for tests — most assertions are substring checks
+// against the output so we don't lock the renderer to exact byte layout.
+func snap(state *menuet.MenuState, items ...menuet.SnapshotItem) menuet.Snapshot {
+	return menuet.Snapshot{
+		Schema: menuet.SnapshotSchema,
+		State:  state,
+		Items:  items,
+	}
+}
+
+func TestRendersTitle(t *testing.T) {
+	got := Render(snap(&menuet.MenuState{Title: "Hello"}), Options{})
+	if !strings.Contains(got, "Hello") {
+		t.Errorf("title not rendered: %s", got)
+	}
+}
+
+func TestRendersRegularItem(t *testing.T) {
+	got := Render(snap(nil, menuet.SnapshotItem{Type: "regular", Text: "Refresh"}), Options{})
+	if !strings.Contains(got, "Refresh") {
+		t.Errorf("item text missing: %s", got)
+	}
+	if !strings.Contains(got, "menu-row") {
+		t.Errorf("menu-row class missing: %s", got)
+	}
+}
+
+func TestRendersSeparator(t *testing.T) {
+	got := Render(snap(nil, menuet.SnapshotItem{Type: "separator"}), Options{})
+	if !strings.Contains(got, "var(--sep)") {
+		t.Errorf("separator not rendered: %s", got)
+	}
+}
+
+func TestRendersStateCheckmark(t *testing.T) {
+	got := Render(snap(nil, menuet.SnapshotItem{Type: "regular", Text: "Notify", State: true}), Options{})
+	if !strings.Contains(got, "✓") {
+		t.Errorf("checkmark missing for State=true: %s", got)
+	}
+}
+
+func TestRendersShortcut(t *testing.T) {
+	got := Render(snap(nil, menuet.SnapshotItem{
+		Type: "regular", Text: "Quit",
+		Shortcut: &menuet.Shortcut{KeyCode: 12, Modifiers: menuet.ModCmd}, // ⌘Q
+	}), Options{})
+	if !strings.Contains(got, "⌘Q") {
+		t.Errorf("shortcut missing: %s", got)
+	}
+}
+
+func TestRendersSubtitle(t *testing.T) {
+	got := Render(snap(nil, menuet.SnapshotItem{
+		Type: "regular", Text: "Lakers vs Warriors",
+		Subtitle: []menuet.TextRun{{Text: "Q4 · 2:14 left"}},
+	}), Options{})
+	if !strings.Contains(got, "Q4 · 2:14 left") {
+		t.Errorf("subtitle missing: %s", got)
+	}
+}
+
+func TestRendersSubmenuChevron(t *testing.T) {
+	got := Render(snap(nil, menuet.SnapshotItem{
+		Type: "regular", Text: "Favorites",
+		Children: []menuet.SnapshotItem{{Type: "regular", Text: "Lakers"}},
+	}), Options{})
+	if !strings.Contains(got, "<polyline") {
+		t.Errorf("submenu chevron missing: %s", got)
+	}
+}
+
+func TestRendersSearchField(t *testing.T) {
+	got := Render(snap(nil, menuet.SnapshotItem{Type: "search", Text: "Search teams…"}), Options{})
+	if !strings.Contains(got, "Search teams…") {
+		t.Errorf("search placeholder missing: %s", got)
+	}
+}
+
+func TestRendersBadge(t *testing.T) {
+	got := Render(snap(nil, menuet.SnapshotItem{
+		Type: "regular",
+		Runs: []menuet.TextRun{
+			{Text: "Lakers"}, {Text: "LIVE", Badge: true, Color: menuet.SystemRed},
+		},
+	}), Options{})
+	if !strings.Contains(got, "LIVE") {
+		t.Errorf("badge text missing: %s", got)
+	}
+	if !strings.Contains(got, "border-radius:4px") {
+		t.Errorf("badge pill style missing: %s", got)
+	}
+}
+
+func TestDarkTheme(t *testing.T) {
+	got := Render(snap(nil), Options{Theme: ThemeDark})
+	if !strings.Contains(got, "rgba(46,46,48,0.74)") {
+		t.Errorf("dark panel bg missing: %s", got)
+	}
+}
+
+func TestAccentOverride(t *testing.T) {
+	got := Render(snap(nil), Options{AccentHex: "#ff00aa"})
+	if !strings.Contains(got, "#ff00aa") {
+		t.Errorf("accent override not applied: %s", got)
+	}
+}
+
+func TestAccentOverrideRejectsGarbage(t *testing.T) {
+	got := Render(snap(nil), Options{AccentHex: `red;background:url(evil)`})
+	if strings.Contains(got, "url(evil)") {
+		t.Errorf("garbage accent leaked into output: %s", got)
+	}
+	if !strings.Contains(got, "#007aff") {
+		t.Errorf("default accent missing after garbage rejection: %s", got)
+	}
+}
+
+// --- Safety boundary tests ---
+//
+// These are the load-bearing tests. The renderer accepts snapshots from
+// arbitrary third-party apps, so XSS and CSS-injection vectors via input
+// data MUST be rendered inert. If any of these fail, fix the renderer
+// before shipping.
+
+func TestEscapesScriptInText(t *testing.T) {
+	got := Render(snap(nil, menuet.SnapshotItem{
+		Type: "regular", Text: `<script>alert(1)</script>`,
+	}), Options{})
+	if strings.Contains(got, "<script>") {
+		t.Fatalf("script tag leaked into output: %s", got)
+	}
+	if !strings.Contains(got, "&lt;script&gt;") {
+		t.Errorf("script tag not escaped: %s", got)
+	}
+}
+
+func TestEscapesScriptInRun(t *testing.T) {
+	got := Render(snap(nil, menuet.SnapshotItem{
+		Type: "regular",
+		Runs: []menuet.TextRun{{Text: `<img src=x onerror=alert(1)>`}},
+	}), Options{})
+	if strings.Contains(got, "<img src=x") {
+		t.Fatalf("img tag leaked: %s", got)
+	}
+}
+
+func TestEscapesQuotesInText(t *testing.T) {
+	got := Render(snap(nil, menuet.SnapshotItem{
+		Type: "regular", Text: `" onmouseover="alert(1)`,
+	}), Options{})
+	if strings.Contains(got, `onmouseover="alert`) {
+		t.Fatalf("attribute-context injection leaked: %s", got)
+	}
+}
+
+func TestRejectsUnknownSemanticColor(t *testing.T) {
+	// A malicious snapshot tries to smuggle CSS via a Semantic value.
+	// colorCSS must drop unknown semantic names entirely so they can
+	// never appear in the style attribute.
+	got := Render(snap(nil, menuet.SnapshotItem{
+		Type: "regular", Text: "x",
+		Color: menuet.Color{Semantic: `red;background:url(http://evil)`},
+	}), Options{})
+	if strings.Contains(got, "url(http://evil)") {
+		t.Fatalf("semantic color value leaked into CSS: %s", got)
+	}
+	if strings.Contains(got, "red;background") {
+		t.Fatalf("semantic color string leaked into CSS: %s", got)
+	}
+}
+
+func TestRejectsAbsurdFontSize(t *testing.T) {
+	got := Render(snap(nil, menuet.SnapshotItem{
+		Type: "regular",
+		Runs: []menuet.TextRun{{Text: "x", FontSize: 9999}},
+	}), Options{})
+	if strings.Contains(got, "9999px") {
+		t.Fatalf("absurd font-size accepted: %s", got)
+	}
+}
+
+func TestShadowClamped(t *testing.T) {
+	got := Render(snap(nil, menuet.SnapshotItem{
+		Type: "regular",
+		Runs: []menuet.TextRun{{
+			Text:   "x",
+			Shadow: &menuet.Shadow{Blur: 99999, OffsetX: 99999, OffsetY: 99999, Color: menuet.SystemYellow},
+		}},
+	}), Options{})
+	// We don't assert exact values, just that the absurd ones didn't pass through.
+	if strings.Contains(got, "99999") {
+		t.Fatalf("shadow values not clamped: %s", got)
+	}
+	if !strings.Contains(got, "text-shadow:") {
+		t.Errorf("shadow not emitted at all: %s", got)
+	}
+}
+
+func TestRecursionDepthCappedInRenderer(t *testing.T) {
+	// We don't directly test menuet's snapshotter here, but the renderer
+	// must not crash on a snapshot with deep submenus. Build one 50 deep.
+	leaf := menuet.SnapshotItem{Type: "regular", Text: "leaf"}
+	for i := 0; i < 50; i++ {
+		leaf = menuet.SnapshotItem{Type: "regular", Text: "x", Children: []menuet.SnapshotItem{leaf}}
+	}
+	// Must not panic.
+	_ = Render(snap(nil, leaf), Options{})
+}
+
+func TestSchemaMismatchEmitsComment(t *testing.T) {
+	s := menuet.Snapshot{Schema: "menuet-snapshot/v999", Items: []menuet.SnapshotItem{
+		{Type: "regular", Text: "x"},
+	}}
+	got := Render(s, Options{})
+	if !strings.Contains(got, "unknown schema") {
+		t.Errorf("schema mismatch comment missing: %s", got)
+	}
+	if !strings.Contains(got, ">x<") {
+		t.Errorf("items still rendered best-effort: %s", got)
+	}
+}
+
+func TestRoundTripsThroughJSON(t *testing.T) {
+	// End-to-end: encode a snapshot, decode it, render. Ensures the
+	// JSON tags are right and nothing gets lost in serialization.
+	in := snap(&menuet.MenuState{
+		Runs: []menuet.TextRun{
+			{Text: "GSW ", FontWeight: menuet.WeightSemibold},
+			{Text: "71", Monospaced: true},
+		},
+	},
+		menuet.SnapshotItem{Type: "regular", Text: "Refresh"},
+		menuet.SnapshotItem{Type: "separator"},
+		menuet.SnapshotItem{Type: "regular", Text: "Quit",
+			Shortcut: &menuet.Shortcut{KeyCode: 12, Modifiers: menuet.ModCmd}},
+	)
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out menuet.Snapshot
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	got := Render(out, Options{})
+	for _, want := range []string{"GSW", "71", "Refresh", "Quit", "⌘Q"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in round-trip output: %s", want, got)
+		}
+	}
+}

--- a/html/run.go
+++ b/html/run.go
@@ -1,0 +1,326 @@
+package html
+
+import (
+	"fmt"
+	stdhtml "html"
+	"strings"
+
+	"github.com/caseymrm/menuet/v2"
+)
+
+// renderRun emits one TextRun as a <span> with a whitelisted set of CSS
+// properties. inBar tweaks the rendering to fit the menu-bar strip
+// (smaller default size, slightly tighter letter-spacing).
+//
+// This is the only place untrusted data turns into HTML. Every text
+// value is HTML-escaped; every color, weight, and shadow is validated
+// before being written to the style attribute. The renderer never emits
+// arbitrary CSS — only properties from the fixed whitelist below.
+func renderRun(b *strings.Builder, run menuet.TextRun, inBar bool) {
+	if run.Badge {
+		renderBadge(b, run)
+		return
+	}
+	var style strings.Builder
+	if c := colorCSS(run.Color); c != "" {
+		fmt.Fprintf(&style, "color:%s;", c)
+	}
+	if w := weightCSS(run.FontWeight); w != "" {
+		fmt.Fprintf(&style, "font-weight:%s;", w)
+	}
+	if run.FontSize > 0 && run.FontSize <= 96 {
+		fmt.Fprintf(&style, "font-size:%dpx;", run.FontSize)
+	}
+	if run.Monospaced {
+		style.WriteString("font-family:'IBM Plex Mono',ui-monospace,monospace;letter-spacing:-0.02em;")
+	} else if inBar {
+		style.WriteString("font-weight:600;")
+	}
+	if run.Underline || run.Strikethrough {
+		var decos []string
+		if run.Underline {
+			decos = append(decos, "underline")
+		}
+		if run.Strikethrough {
+			decos = append(decos, "line-through")
+		}
+		fmt.Fprintf(&style, "text-decoration:%s;", strings.Join(decos, " "))
+		// When a separate underline/strikethrough color is given, prefer
+		// underline's; strikethrough's is honored only if underline isn't
+		// set. The two-color case (different colors for both) isn't
+		// representable in standard CSS, so we accept the limitation.
+		if c := colorCSS(run.UnderlineColor); run.Underline && c != "" {
+			fmt.Fprintf(&style, "text-decoration-color:%s;", c)
+		} else if c := colorCSS(run.StrikethroughColor); run.Strikethrough && c != "" {
+			fmt.Fprintf(&style, "text-decoration-color:%s;", c)
+		}
+	}
+	if c := colorCSS(run.Background); c != "" {
+		fmt.Fprintf(&style, "background:%s;padding:0 3px;border-radius:3px;", c)
+	}
+	if run.Shadow != nil {
+		ox := clampFloat(run.Shadow.OffsetX, -32, 32)
+		// AppKit's y is "up positive"; CSS's y is "down positive". Flip.
+		oy := -clampFloat(run.Shadow.OffsetY, -32, 32)
+		blur := clampFloat(run.Shadow.Blur, 0, 64)
+		c := colorCSS(run.Shadow.Color)
+		if c == "" {
+			c = "rgba(0,0,0,0.5)"
+		}
+		fmt.Fprintf(&style, "text-shadow:%gpx %gpx %gpx %s;", ox, oy, blur, c)
+	}
+	b.WriteString(`<span style="`)
+	b.WriteString(style.String())
+	b.WriteString(`">`)
+	b.WriteString(stdhtml.EscapeString(run.Text))
+	b.WriteString(`</span>`)
+}
+
+// renderBadge emits a TextRun marked Badge=true as a filled rounded pill,
+// matching the look of the LIVE chip in the menu-bar mockup.
+func renderBadge(b *strings.Builder, run menuet.TextRun) {
+	bg := colorCSS(run.Color)
+	if bg == "" {
+		bg = "var(--live)"
+	}
+	fmt.Fprintf(b,
+		`<span style="font-size:9px;font-weight:700;letter-spacing:0.05em;background:%s;color:#fff;padding:1px 5px;border-radius:4px;line-height:1.5;">%s</span>`,
+		bg, stdhtml.EscapeString(run.Text))
+}
+
+// colorCSS returns a CSS color value for a menuet.Color, or "" if the
+// color is the zero value. Semantic names are mapped to their NSColor
+// equivalents (and to --accent for the system accent); any unknown
+// semantic name is rejected as "" so injected names can't leak through.
+func colorCSS(c menuet.Color) string {
+	if c.IsZero() {
+		return ""
+	}
+	if c.Semantic != "" {
+		v, ok := semanticColors[c.Semantic]
+		if !ok {
+			return "" // unknown semantic name — drop, don't pass through
+		}
+		return v
+	}
+	return fmt.Sprintf("rgba(%d,%d,%d,%g)", c.R, c.G, c.B, float64(c.A)/255.0)
+}
+
+// semanticColors maps the menuet.Color.Semantic names to fixed CSS
+// values. Keep in lockstep with formatting.go's semantic vars. We do NOT
+// pass the Semantic string through to CSS — the whitelist below is the
+// safety boundary that prevents `Semantic: "red; background: url(evil)"`
+// from being interpreted as raw CSS.
+var semanticColors = map[string]string{
+	"labelColor":            "var(--text)",
+	"secondaryLabelColor":   "var(--text-2)",
+	"tertiaryLabelColor":    "var(--text-3)",
+	"quaternaryLabelColor":  "var(--text-3)",
+	"systemRedColor":        "#ff3b30",
+	"systemGreenColor":      "#34c759",
+	"systemYellowColor":     "#ffcc00",
+	"systemBlueColor":       "var(--accent)",
+	"systemOrangeColor":     "#ff9500",
+	"systemPurpleColor":     "#af52de",
+	"systemPinkColor":       "#ff2d55",
+	"systemGrayColor":       "#8e8e93",
+	"systemBrownColor":      "#a2845e",
+	"systemTealColor":       "#5ac8fa",
+	"systemIndigoColor":     "#5856d6",
+	"systemMintColor":       "#00c7be",
+	"systemCyanColor":       "#32ade6",
+}
+
+// weightCSS maps menuet.FontWeight (NSFontWeight scale) to a numeric CSS
+// font-weight. Bounds chosen to span the full NS scale; values outside
+// the range are dropped to inherit.
+func weightCSS(w menuet.FontWeight) string {
+	switch {
+	case w <= -0.7:
+		return "100" // UltraLight
+	case w <= -0.5:
+		return "200" // Thin
+	case w <= -0.3:
+		return "300" // Light
+	case w < 0.2:
+		return "" // Regular = inherit
+	case w < 0.27:
+		return "500" // Medium
+	case w < 0.35:
+		return "600" // Semibold
+	case w < 0.5:
+		return "700" // Bold
+	case w < 0.59:
+		return "800" // Heavy
+	default:
+		return "900" // Black
+	}
+}
+
+// shortcutString formats a Shortcut as the Apple-standard display
+// (⌃⌥⇧⌘ then key glyph). Keep the key-code map in sync with
+// MenuetKeyEquivalentStringForCode in menuet.m.
+func shortcutString(s menuet.Shortcut) string {
+	var b strings.Builder
+	if s.Modifiers&menuet.ModCtrl != 0 {
+		b.WriteString("⌃")
+	}
+	if s.Modifiers&menuet.ModAlt != 0 {
+		b.WriteString("⌥")
+	}
+	if s.Modifiers&menuet.ModShift != 0 {
+		b.WriteString("⇧")
+	}
+	if s.Modifiers&menuet.ModCmd != 0 {
+		b.WriteString("⌘")
+	}
+	b.WriteString(keyCodeGlyph(s.KeyCode))
+	return b.String()
+}
+
+// keyCodeGlyph maps a macOS virtual key code to its menu-display glyph.
+// Letters are uppercased to match Apple's HIG. Unknown codes render as
+// the empty string.
+func keyCodeGlyph(code uint16) string {
+	switch code {
+	case 0:
+		return "A"
+	case 11:
+		return "B"
+	case 8:
+		return "C"
+	case 2:
+		return "D"
+	case 14:
+		return "E"
+	case 3:
+		return "F"
+	case 5:
+		return "G"
+	case 4:
+		return "H"
+	case 34:
+		return "I"
+	case 38:
+		return "J"
+	case 40:
+		return "K"
+	case 37:
+		return "L"
+	case 46:
+		return "M"
+	case 45:
+		return "N"
+	case 31:
+		return "O"
+	case 35:
+		return "P"
+	case 12:
+		return "Q"
+	case 15:
+		return "R"
+	case 1:
+		return "S"
+	case 17:
+		return "T"
+	case 32:
+		return "U"
+	case 9:
+		return "V"
+	case 13:
+		return "W"
+	case 7:
+		return "X"
+	case 16:
+		return "Y"
+	case 6:
+		return "Z"
+	case 29:
+		return "0"
+	case 18:
+		return "1"
+	case 19:
+		return "2"
+	case 20:
+		return "3"
+	case 21:
+		return "4"
+	case 23:
+		return "5"
+	case 22:
+		return "6"
+	case 26:
+		return "7"
+	case 28:
+		return "8"
+	case 25:
+		return "9"
+	case 49:
+		return "␣" // space glyph
+	case 36:
+		return "↩"
+	case 48:
+		return "⇥"
+	case 53:
+		return "⎋"
+	case 122:
+		return "F1"
+	case 120:
+		return "F2"
+	case 99:
+		return "F3"
+	case 118:
+		return "F4"
+	case 96:
+		return "F5"
+	case 97:
+		return "F6"
+	case 98:
+		return "F7"
+	case 100:
+		return "F8"
+	case 101:
+		return "F9"
+	case 109:
+		return "F10"
+	case 103:
+		return "F11"
+	case 111:
+		return "F12"
+	case 123:
+		return "←"
+	case 124:
+		return "→"
+	case 125:
+		return "↓"
+	case 126:
+		return "↑"
+	}
+	return ""
+}
+
+func clampFloat(v, lo, hi float64) float64 {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}
+
+// isHexColor reports whether s is "#" + 6 hex digits. Used to validate
+// the caller-supplied AccentHex before letting it into CSS.
+func isHexColor(s string) bool {
+	if len(s) != 7 || s[0] != '#' {
+		return false
+	}
+	for i := 1; i < 7; i++ {
+		c := s[i]
+		ok := (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
+		if !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/menuet.go
+++ b/menuet.go
@@ -85,8 +85,17 @@ func App() *Application {
 	return appInstance
 }
 
-// RunApplication does not return
+// RunApplication does not return, unless MENUET_SNAPSHOT_PATH is set —
+// in which case it writes a JSON snapshot of the current MenuState and
+// resolved top-level Children (with submenus recursively expanded) and
+// returns without entering the AppKit run loop. See snapshot.go for the
+// snapshot format; the `web-preview` Makefile target is the intended
+// driver. Also honors MENUET_SNAPSHOT_DELAY (default 2s) to give startup
+// goroutines time to populate state.
 func (a *Application) RunApplication() {
+	if a.maybeWriteSnapshot() {
+		return
+	}
 	if a.AutoUpdate.Version != "" && a.AutoUpdate.Repo != "" {
 		go a.checkForUpdates()
 	}

--- a/menuet.mk
+++ b/menuet.mk
@@ -104,3 +104,16 @@ $(PLIST):
 .PHONY: sign
 sign: $(BINARY) $(PLIST)
 	codesign -f -s "$(IDENTITY)" $(ESCAPED_APP).app --deep
+
+# `make web-preview` writes menuet-demo.json — a JSON snapshot of the
+# current MenuState and resolved menu items — by re-running the binary
+# in snapshot mode. The snapshot is safe to commit to your repo;
+# menuet.app fetches it to render a faithful HTML mockup of your menu.
+#
+# Default delay is 2s; override with MENUET_SNAPSHOT_DELAY=5s when your
+# app fetches data on startup and you want the menu to reflect real
+# values in the demo.
+.PHONY: web-preview
+web-preview: $(BINARY) $(PLIST)
+	MENUET_SNAPSHOT_PATH=menuet-demo.json ./$(BINARY)
+	@echo "Wrote menuet-demo.json"

--- a/snapshot.go
+++ b/snapshot.go
@@ -1,0 +1,165 @@
+package menuet
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+)
+
+// SnapshotSchema is the version string embedded in every snapshot file.
+// Bump this when the snapshot JSON shape changes so consumers can detect
+// incompatible versions. Existing fields should never change meaning.
+const SnapshotSchema = "menuet-snapshot/v1"
+
+// snapshotMaxDepth caps recursion into submenus when building a snapshot.
+// A malformed Children callback that always returns more children would
+// otherwise hang the snapshot. Eight levels is far past anything sensible
+// in a menu.
+const snapshotMaxDepth = 8
+
+// Snapshot is a JSON-serializable picture of an App's current menu —
+// MenuState plus the resolved top-level items, with submenus recursively
+// expanded. It's produced by `MENUET_SNAPSHOT_PATH=… ./app` and consumed
+// by the HTML renderer to draw a faithful mockup outside AppKit (for
+// websites, README screenshots, regression tests).
+//
+// The snapshot is pure data — there is no code path back to the app from
+// a snapshot file, so rendering one is safe even if the file came from a
+// third party. The renderer's job is to honor the data and reject any
+// shape outside the schema.
+type Snapshot struct {
+	Schema string         `json:"schema"`
+	State  *MenuState     `json:"state,omitempty"`
+	Items  []SnapshotItem `json:"items"`
+}
+
+// SnapshotItem is the snapshot-only mirror of MenuItem. It is intentionally
+// separate from internalItem (which carries cgo bookkeeping fields like
+// Unique/ParentUnique and a live *MenuItem pointer) so the snapshot stays
+// a self-contained data payload with no live references.
+type SnapshotItem struct {
+	// Type is "regular", "separator", or "search". Empty means regular for
+	// backward-compatibility when the field is omitted.
+	Type string `json:"type,omitempty"`
+
+	Text       string     `json:"text,omitempty"`
+	Runs       []TextRun  `json:"runs,omitempty"`
+	Subtitle   []TextRun  `json:"subtitle,omitempty"`
+	Image      string     `json:"image,omitempty"`
+	FontSize   int        `json:"fontSize,omitempty"`
+	FontWeight FontWeight `json:"fontWeight,omitempty"`
+	Color      Color      `json:"color,omitempty"`
+	Monospaced bool       `json:"monospaced,omitempty"`
+	Shortcut   *Shortcut  `json:"shortcut,omitempty"`
+	State      bool       `json:"state,omitempty"`
+
+	// Children are the expanded submenu, populated by the snapshotter.
+	Children []SnapshotItem `json:"children,omitempty"`
+}
+
+// maybeWriteSnapshot is the entry point used by RunApplication. If
+// MENUET_SNAPSHOT_PATH is unset, it returns false and normal startup
+// continues. If set, it waits MENUET_SNAPSHOT_DELAY (default 2s) so the
+// app's startup goroutines have a chance to populate state, then writes
+// the snapshot to the path and returns true. The caller is expected to
+// short-circuit further startup (no AppKit, no Carbon, no goroutines)
+// when it returns true.
+//
+// The delay is the one tunable: an app that fetches data on startup will
+// often want a longer delay before its menu reflects real values. Set
+// MENUET_SNAPSHOT_DELAY=5s (or any time.Duration string) to override.
+func (a *Application) maybeWriteSnapshot() bool {
+	path := os.Getenv("MENUET_SNAPSHOT_PATH")
+	if path == "" {
+		return false
+	}
+	delay := 2 * time.Second
+	if s := os.Getenv("MENUET_SNAPSHOT_DELAY"); s != "" {
+		d, err := time.ParseDuration(s)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "menuet: invalid MENUET_SNAPSHOT_DELAY %q: %v\n", s, err)
+			os.Exit(2)
+		}
+		delay = d
+	}
+	time.Sleep(delay)
+	if err := a.writeSnapshot(path); err != nil {
+		fmt.Fprintf(os.Stderr, "menuet: snapshot write failed: %v\n", err)
+		os.Exit(1)
+	}
+	return true
+}
+
+// writeSnapshot captures the current MenuState and top-level Children,
+// recursively expands submenus, and writes the result as indented JSON.
+func (a *Application) writeSnapshot(path string) error {
+	snap := Snapshot{
+		Schema: SnapshotSchema,
+		State:  a.currentState,
+	}
+	if a.Children != nil {
+		snap.Items = snapshotItems(a.Children(), 0)
+	}
+	b, err := json.MarshalIndent(snap, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	b = append(b, '\n')
+	if err := os.WriteFile(path, b, 0644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+// snapshotItems converts a []MenuItem to []SnapshotItem, recursing into
+// each item's Children callback up to snapshotMaxDepth. It deliberately
+// does NOT share code with buildInternalItem because that path has cgo
+// side effects (registerGlobalHotkey) that must not fire during a
+// snapshot.
+func snapshotItems(items []MenuItem, depth int) []SnapshotItem {
+	if depth >= snapshotMaxDepth {
+		return nil
+	}
+	out := make([]SnapshotItem, len(items))
+	for i, item := range items {
+		out[i] = snapshotItem(item, depth)
+	}
+	return out
+}
+
+func snapshotItem(item MenuItem, depth int) SnapshotItem {
+	switch v := item.(type) {
+	case Regular:
+		s := SnapshotItem{
+			Type:       "regular",
+			Text:       v.Text,
+			Runs:       v.Runs,
+			Subtitle:   v.Subtitle,
+			Image:      v.Image,
+			FontSize:   v.FontSize,
+			FontWeight: v.FontWeight,
+			Color:      v.Color,
+			Monospaced: v.Monospaced,
+			Shortcut:   v.Shortcut,
+			State:      v.State,
+		}
+		if v.Children != nil {
+			s.Children = snapshotItems(v.Children(), depth+1)
+		}
+		return s
+	case Separator:
+		return SnapshotItem{Type: "separator"}
+	case Search:
+		s := SnapshotItem{Type: "search", Text: v.Placeholder}
+		// Snapshot search results with an empty query — the same call the
+		// real menu makes when the search field first appears. Authors who
+		// want a richer demo can synthesize results conditionally on the
+		// MENUET_SNAPSHOT_PATH env var inside their Results callback.
+		if v.Results != nil {
+			s.Children = snapshotItems(v.Results(""), depth+1)
+		}
+		return s
+	}
+	return SnapshotItem{}
+}

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -1,0 +1,119 @@
+package menuet
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSnapshotItemsBasicShape(t *testing.T) {
+	items := []MenuItem{
+		Regular{Text: "Refresh", Shortcut: &Shortcut{KeyCode: 15, Modifiers: ModCmd}},
+		Separator{},
+		Regular{Text: "Notify on scoring plays", State: true},
+	}
+	got := snapshotItems(items, 0)
+	if len(got) != 3 {
+		t.Fatalf("want 3 items, got %d", len(got))
+	}
+	if got[0].Type != "regular" || got[0].Text != "Refresh" {
+		t.Errorf("first item: %+v", got[0])
+	}
+	if got[0].Shortcut == nil || got[0].Shortcut.Modifiers != ModCmd {
+		t.Errorf("shortcut lost: %+v", got[0])
+	}
+	if got[1].Type != "separator" {
+		t.Errorf("separator: %+v", got[1])
+	}
+	if !got[2].State {
+		t.Errorf("State not captured: %+v", got[2])
+	}
+}
+
+func TestSnapshotRecursesIntoChildren(t *testing.T) {
+	items := []MenuItem{
+		Regular{
+			Text: "Favorites",
+			Children: func() []MenuItem {
+				return []MenuItem{Regular{Text: "Lakers"}}
+			},
+		},
+	}
+	got := snapshotItems(items, 0)
+	if len(got[0].Children) != 1 || got[0].Children[0].Text != "Lakers" {
+		t.Errorf("submenu not captured: %+v", got)
+	}
+}
+
+func TestSnapshotCapsDepth(t *testing.T) {
+	// A pathological recursive Children that always returns one more level.
+	var build func(depth int) MenuItem
+	build = func(depth int) MenuItem {
+		return Regular{
+			Text: "x",
+			Children: func() []MenuItem {
+				return []MenuItem{build(depth + 1)}
+			},
+		}
+	}
+	got := snapshotItems([]MenuItem{build(0)}, 0)
+	depth := 0
+	cur := got[0]
+	for len(cur.Children) > 0 {
+		depth++
+		cur = cur.Children[0]
+		if depth > snapshotMaxDepth+2 {
+			t.Fatalf("recursion not capped: still going at depth %d", depth)
+		}
+	}
+}
+
+func TestSnapshotDoesNotRegisterHotkey(t *testing.T) {
+	// buildInternalItem registers a Carbon hotkey when a Regular has both
+	// a Shortcut and a Clicked callback. snapshotItem must NOT — calling
+	// registerGlobalHotkey from a CLI snapshot would crash (no AppKit run
+	// loop) or leak Carbon resources into a soon-to-exit process. This
+	// test simply exercises the path and relies on the absence of any cgo
+	// call (the test runs without an AppKit loop).
+	items := []MenuItem{Regular{
+		Text:     "Refresh",
+		Shortcut: &Shortcut{KeyCode: 15, Modifiers: ModCmd},
+		Clicked:  func() {},
+	}}
+	got := snapshotItems(items, 0)
+	if got[0].Shortcut == nil {
+		t.Errorf("shortcut lost: %+v", got[0])
+	}
+}
+
+func TestWriteSnapshotProducesValidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demo.json")
+	a := &Application{
+		currentState: &MenuState{Title: "Hello"},
+		Children: func() []MenuItem {
+			return []MenuItem{Regular{Text: "Refresh"}}
+		},
+	}
+	if err := a.writeSnapshot(path); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var snap Snapshot
+	if err := json.Unmarshal(b, &snap); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, b)
+	}
+	if snap.Schema != SnapshotSchema {
+		t.Errorf("schema: got %q", snap.Schema)
+	}
+	if snap.State == nil || snap.State.Title != "Hello" {
+		t.Errorf("state: %+v", snap.State)
+	}
+	if len(snap.Items) != 1 || snap.Items[0].Text != "Refresh" {
+		t.Errorf("items: %+v", snap.Items)
+	}
+}


### PR DESCRIPTION
## Summary

Two pieces that work together to make it possible to render an AppKit-faithful mockup of a menuet menu *outside* AppKit — for the menuet.app website, README screenshots, regression tests, etc.

### 1. Snapshot mode (no source changes needed in apps)

`RunApplication` checks `MENUET_SNAPSHOT_PATH`. If set:

- Waits `MENUET_SNAPSHOT_DELAY` (default 2s) so startup goroutines populate state
- Writes JSON of current `MenuState` + resolved `Children()` (submenus recursively expanded up to 8 levels)
- Returns without entering the AppKit run loop

Apps gain a `web-preview` Makefile target via `menuet.mk`:

```makefile
make web-preview     # writes menuet-demo.json
```

The snapshotter is deliberately a parallel path to `buildInternalItem` (no `registerGlobalHotkey` side effects when capturing a Shortcut from a soon-to-exit process).

### 2. Pure-Go `html` subpackage

```go
import "github.com/caseymrm/menuet/v2/html"

out := html.Render(snap, html.Options{Theme: html.ThemeLight, AccentHex: "#34c759"})
```

Both light and dark themes. Output is a single `<div class="menumock">` tree using inline styles + CSS custom properties — drops into any page and brings its own scope.

## Why this design

**The renderer is safe to run on snapshots from arbitrary third-party apps.** A renderer that can't be fed untrusted input isn't useful for menuet.app's "Apps built with menuet" showcase. So:

- Every interpolated string is HTML-escaped (`html.EscapeString`)
- `Color.Semantic` values are looked up in a fixed whitelist — unknown semantic names are dropped, never passed through to CSS. (Prevents \`Semantic: "red;background:url(evil)"\` from being interpreted as raw CSS.)
- Font size / shadow blur / offsets are clamped before being written
- Caller `AccentHex` must be `#rrggbb`; anything else is rejected back to the theme default
- Only a fixed set of HTML tags and CSS properties are ever emitted — there is no code path from snapshot data to a raw `<script>` tag, `javascript:` URL, or arbitrary CSS

## Tests

Safety-boundary tests are the load-bearing ones:

- `TestEscapesScriptInText` / `TestEscapesScriptInRun` / `TestEscapesQuotesInText`
- `TestRejectsUnknownSemanticColor`
- `TestRejectsAbsurdFontSize` / `TestShadowClamped`
- `TestAccentOverrideRejectsGarbage`
- `TestRecursionDepthCappedInRenderer`
- `TestSchemaMismatchEmitsComment`

Plus rendering coverage for subtitles, shortcuts (with full key-code glyph map), badges, submenu chevrons, search fields, both themes, and a full JSON round-trip.

## End-to-end check

`MENUET_SNAPSHOT_PATH=demo.json ./cmd/catalog` produces a 2311-line JSON snapshot; the renderer turns it into a 5.4KB HTML fragment.

## Why no source-level changes in consuming apps

Each consuming app gets the new behavior just by bumping to the next menuet release and adding a `web-preview` Makefile target. The env-var gate keeps the snapshot path entirely opt-in and has zero runtime cost when unset.

## Test plan

- [ ] `go test ./...` passes
- [ ] `MENUET_SNAPSHOT_PATH=demo.json ./helloworld` writes valid JSON
- [ ] Snapshot of cmd/catalog renders cleanly through `html.Render`