### PR TITLE
html: ExpandSubmenus → hover-popover semantics

### DIFF
--- a/html/render.go
+++ b/html/render.go
@@ -214,17 +214,21 @@ func renderItem(b *strings.Builder, item menuet.SnapshotItem, opts Options, dept
 			renderItem(b, child, opts, depth)
 		}
 	default:
-		renderRegular(b, item)
-		if opts.ExpandSubmenus && len(item.Children) > 0 && depth < opts.maxSubmenuDepth() {
-			renderSubmenuBlock(b, item.Children, opts, depth+1)
-		}
+		renderRegular(b, item, opts, depth)
 	}
 }
 
-// renderSubmenuBlock renders a Regular's children inline, indented from
-// the parent row with a left border to mark the hierarchy. Capped by
-// MaxSubmenuItems; truncation gets a "+N more" footer.
-func renderSubmenuBlock(b *strings.Builder, children []menuet.SnapshotItem, opts Options, depth int) {
+// renderHoverSubmenu emits a hidden-by-default submenu popover inside
+// the parent .menu-row. The host page is expected to reveal it on hover:
+//
+//	.menumock .menu-row:hover > .menu-submenu { display: block; }
+//
+// This matches macOS's behavior: the menu stays a flat top-level list
+// until you hover an item, at which point its submenu opens flush to
+// the right. `left: 100%; padding-left: 4px;` keeps the hover area
+// bridged across the visual gap so the popover doesn't blink off when
+// the cursor crosses into it.
+func renderHoverSubmenu(b *strings.Builder, children []menuet.SnapshotItem, opts Options, depth int) {
 	max := opts.maxSubmenuItems()
 	visible := children
 	truncated := 0
@@ -232,25 +236,31 @@ func renderSubmenuBlock(b *strings.Builder, children []menuet.SnapshotItem, opts
 		truncated = len(visible) - max
 		visible = visible[:max]
 	}
-	// Container indented past the parent's checkmark gutter, with a left
-	// border tracing the menu hierarchy.
-	b.WriteString(`<div style="margin: 2px 5px 4px 18px; border-left: 1.5px solid var(--sep); padding-left: 2px;">`)
+	b.WriteString(`<div class="menu-submenu" style="display: none; position: absolute; left: 100%; top: -5px; padding-left: 4px; z-index: 20;">`)
+	b.WriteString(`<div style="width: 260px; background: var(--panel-bg); -webkit-backdrop-filter: blur(34px) saturate(1.7); backdrop-filter: blur(34px) saturate(1.7); border: 0.5px solid var(--panel-border); border-radius: 11px; box-shadow: var(--shadow); padding: 5px 0;">`)
 	for _, c := range visible {
 		renderItem(b, c, opts, depth)
 	}
 	if truncated > 0 {
 		fmt.Fprintf(b, `<div style="margin: 2px 5px 0; padding: 0 9px 0 7px; font-size: 11.5px; color: var(--text-3); font-style: italic;">+%d more…</div>`, truncated)
 	}
-	b.WriteString(`</div>`)
+	b.WriteString(`</div></div>`)
 }
 
-func renderRegular(b *strings.Builder, item menuet.SnapshotItem) {
+func renderRegular(b *strings.Builder, item menuet.SnapshotItem, opts Options, depth int) {
 	hasSubtitle := len(item.Subtitle) > 0
 	hasChildren := len(item.Children) > 0
+	needsSubmenu := opts.ExpandSubmenus && hasChildren && depth < opts.maxSubmenuDepth()
+	// position:relative anchors the absolute-positioned .menu-submenu
+	// child to this row.
+	posStyle := ""
+	if needsSubmenu {
+		posStyle = "position: relative; "
+	}
 	if hasSubtitle {
-		b.WriteString(`<div class="menu-row" style="margin: 0 5px; padding: 5px 9px 6px 7px; border-radius: 6px; display: flex; align-items: flex-start; gap: 7px;">`)
+		fmt.Fprintf(b, `<div class="menu-row" style="%smargin: 0 5px; padding: 5px 9px 6px 7px; border-radius: 6px; display: flex; align-items: flex-start; gap: 7px;">`, posStyle)
 	} else {
-		b.WriteString(`<div class="menu-row" style="margin: 0 5px; padding: 0 9px 0 7px; min-height: 24px; border-radius: 6px; display: flex; align-items: center; gap: 7px; font-size: 13.5px; color: var(--text);">`)
+		fmt.Fprintf(b, `<div class="menu-row" style="%smargin: 0 5px; padding: 0 9px 0 7px; min-height: 24px; border-radius: 6px; display: flex; align-items: center; gap: 7px; font-size: 13.5px; color: var(--text);">`, posStyle)
 	}
 
 	// Checkmark gutter, always 14px wide so labels line up whether or not
@@ -283,6 +293,9 @@ func renderRegular(b *strings.Builder, item menuet.SnapshotItem) {
 		} else if hasChildren {
 			b.WriteString(`<svg width="7" height="11" viewBox="0 0 7 11" fill="none" style="opacity: 0.5;"><polyline points="1,1 6,5.5 1,10" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"></polyline></svg>`)
 		}
+	}
+	if needsSubmenu {
+		renderHoverSubmenu(b, item.Children, opts, depth+1)
 	}
 	b.WriteString(`</div>`)
 }

--- a/html/render_test.go
+++ b/html/render_test.go
@@ -84,7 +84,7 @@ func TestRendersSubmenuChevron(t *testing.T) {
 	}
 }
 
-func TestExpandSubmenusRendersChildrenInline(t *testing.T) {
+func TestExpandSubmenusRendersAsHoverPopover(t *testing.T) {
 	got := Render(snap(nil, menuet.SnapshotItem{
 		Type: "regular", Text: "Favorites",
 		Children: []menuet.SnapshotItem{
@@ -96,6 +96,17 @@ func TestExpandSubmenusRendersChildrenInline(t *testing.T) {
 		if !strings.Contains(got, ">"+want+"<") {
 			t.Errorf("missing %q in expanded output: %s", want, got)
 		}
+	}
+	// Submenu must be hidden by default — host CSS reveals on :hover.
+	if !strings.Contains(got, `class="menu-submenu"`) {
+		t.Errorf("submenu wrapper class missing: %s", got)
+	}
+	if !strings.Contains(got, "display: none") {
+		t.Errorf("submenu not hidden by default: %s", got)
+	}
+	// Parent row must be position:relative so the submenu anchors to it.
+	if !strings.Contains(got, "position: relative") {
+		t.Errorf("parent row missing position:relative anchor: %s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

v2.10.1's ExpandSubmenus rendered the whole nested tree inline indented, which looked like a wall of cascaded items rather than a menu. This rewrites the behavior to match macOS: submenu hidden by default, revealed by hovering the parent row.

## Behavior

Each submenu now renders as a hidden absolutely-positioned popover anchored inside its parent row. The host page's CSS reveals it on hover:

\`\`\`css
.menumock .menu-row:hover > .menu-submenu { display: block; }
\`\`\`

Default look = clean top-level menu, exactly like macOS.

## Test plan

- [x] \`go test ./html/...\` passes (existing tests + new \`TestExpandSubmenusRendersAsHoverPopover\` validates the structure)