### PR TITLE
Document module-aware menuet.mk include path

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,11 @@ app directory, create a `Makefile` like:
 ```make
 APP=My App
 IDENTIFIER=com.example.myapp
-include $(GOPATH)/src/github.com/caseymrm/menuet/menuet.mk
+include $(shell go list -m -f '{{.Dir}}' github.com/caseymrm/menuet)/menuet.mk
 ```
+
+(`go list -m` locates menuet in the module cache; the old
+`$(GOPATH)/src/...` path only works for pre-modules GOPATH checkouts.)
 
 Then `make run` builds the binary into `My App.app/Contents/MacOS/myapp`,
 generates `My App.app/Contents/Info.plist` with your `CFBundleIdentifier`,

--- a/menuet.mk
+++ b/menuet.mk
@@ -3,7 +3,10 @@
 # For example:
 #
 #   APP=Hello World
-#   include $(GOPATH)/src/github.com/caseymrm/menuet/menuet.mk
+#   include $(shell go list -m -f '{{.Dir}}' github.com/caseymrm/menuet)/menuet.mk
+#
+# (go list -m finds menuet in the module cache; use a direct path instead
+# if you have a local checkout.)
 #
 # Optional features:
 # 


### PR DESCRIPTION
The README and the `menuet.mk` header both showed the pre-modules include path:

```make
include $(GOPATH)/src/github.com/caseymrm/menuet/menuet.mk
```

which doesn't exist for Go-modules consumers (nothing is checked out under `$(GOPATH)/src` anymore). This updates both to locate menuet in the module cache:

```make
include $(shell go list -m -f '{{.Dir}}' github.com/caseymrm/menuet)/menuet.mk
```

This is the pattern [tally](https://github.com/caseymrm/tally) uses; `make run` works against the module cache copy (find(1) on the read-only cache dir for the source-change checks is fine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmSeWbtYum34tu1PGBK1Lj