### PR TITLE
googleauth: reusable Sign in with Google (loopback + PKCE)

### DIFF
--- a/googleauth/googleauth.go
+++ b/googleauth/googleauth.go
@@ -1,0 +1,342 @@
+// Package googleauth implements a reusable "Sign in with Google" flow for
+// native desktop apps using OAuth 2.0 with a loopback redirect and PKCE.
+//
+// It is the Apple/Google-recommended native-app flow: it opens the system
+// browser to Google, catches the redirect on a transient 127.0.0.1:<random>
+// HTTP server, exchanges the authorization code for tokens, and returns them.
+// No embedded webview and no confidential client secret are required — PKCE is
+// the real protection.
+//
+// The package depends only on the standard library. It imports nothing from the
+// menuet root package, so any Go program can use it by supplying its own Google
+// "Desktop app" OAuth client ID and scopes.
+//
+// Security note: any local application can initiate this flow using the
+// (extractable) desktop client ID; the browser consent step is the only gate.
+// This is inherent to native-app OAuth, not a flaw of this package.
+package googleauth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	defaultAuthURL  = "https://accounts.google.com/o/oauth2/v2/auth"
+	defaultTokenURL = "https://oauth2.googleapis.com/token"
+
+	// defaultTimeout bounds the flow when the caller's context has no deadline.
+	defaultTimeout = 3 * time.Minute
+)
+
+// Config configures a single sign-in attempt.
+type Config struct {
+	// ClientID is the Google "Desktop app" OAuth client ID. Required.
+	ClientID string
+
+	// ClientSecret is optional. Google desktop clients are issued one, but it
+	// is not treated as confidential — PKCE is the real gate. Sent in the token
+	// exchange when present.
+	ClientSecret string
+
+	// Scopes are the OAuth scopes to request, e.g. {"openid","email","profile"}.
+	Scopes []string
+
+	// AuthURL optionally overrides the Google authorization endpoint.
+	AuthURL string
+
+	// TokenURL optionally overrides the Google token endpoint.
+	TokenURL string
+
+	// OpenURL optionally overrides how the authorization URL is opened. The
+	// default execs `open <url>` (macOS). Injectable so tests need not launch a
+	// real browser.
+	OpenURL func(string) error
+}
+
+// Result holds the tokens and identity returned by a successful sign-in.
+type Result struct {
+	IDToken      string // JWT — send to your backend to verify identity.
+	AccessToken  string
+	RefreshToken string
+	Email        string
+	Expiry       time.Time
+}
+
+func (c Config) authURL() string {
+	if c.AuthURL != "" {
+		return c.AuthURL
+	}
+	return defaultAuthURL
+}
+
+func (c Config) tokenURL() string {
+	if c.TokenURL != "" {
+		return c.TokenURL
+	}
+	return defaultTokenURL
+}
+
+func (c Config) openURL() func(string) error {
+	if c.OpenURL != nil {
+		return c.OpenURL
+	}
+	return func(u string) error {
+		return exec.Command("open", u).Run()
+	}
+}
+
+// SignIn runs the loopback + PKCE flow and returns the resulting tokens.
+//
+// It blocks until the browser redirect is received, the context is cancelled,
+// or a timeout elapses (3 minutes when ctx has no deadline). Call it off any UI
+// goroutine.
+func SignIn(ctx context.Context, cfg Config) (*Result, error) {
+	if cfg.ClientID == "" {
+		return nil, errors.New("googleauth: ClientID is required")
+	}
+
+	// Bound the flow if the caller supplied no deadline of their own.
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, defaultTimeout)
+		defer cancel()
+	}
+
+	verifier, err := generateCodeVerifier()
+	if err != nil {
+		return nil, fmt.Errorf("googleauth: generating code verifier: %w", err)
+	}
+	challenge := codeChallenge(verifier)
+
+	state, err := randomState()
+	if err != nil {
+		return nil, fmt.Errorf("googleauth: generating state: %w", err)
+	}
+
+	// Bind explicitly to 127.0.0.1 (never 0.0.0.0) so the callback server is
+	// only reachable from this machine.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("googleauth: opening loopback listener: %w", err)
+	}
+	defer listener.Close()
+
+	port := listener.Addr().(*net.TCPAddr).Port
+	redirectURI := fmt.Sprintf("http://127.0.0.1:%d/callback", port)
+
+	handler, codeCh := newCallbackHandler(state)
+	server := &http.Server{Handler: handler}
+	go server.Serve(listener)
+	defer server.Close()
+
+	authURL := buildAuthURL(cfg, redirectURI, challenge, state)
+	if err := cfg.openURL()(authURL); err != nil {
+		return nil, fmt.Errorf("googleauth: opening browser: %w", err)
+	}
+
+	select {
+	case <-ctx.Done():
+		return nil, fmt.Errorf("googleauth: waiting for callback: %w", ctx.Err())
+	case code := <-codeCh:
+		return exchangeCode(ctx, cfg, code, verifier, redirectURI)
+	}
+}
+
+// buildAuthURL constructs the Google authorization URL.
+func buildAuthURL(cfg Config, redirectURI, challenge, state string) string {
+	q := url.Values{}
+	q.Set("client_id", cfg.ClientID)
+	q.Set("redirect_uri", redirectURI)
+	q.Set("response_type", "code")
+	q.Set("scope", strings.Join(cfg.Scopes, " "))
+	q.Set("code_challenge", challenge)
+	q.Set("code_challenge_method", "S256")
+	q.Set("state", state)
+	q.Set("access_type", "offline")
+	q.Set("prompt", "select_account")
+	return cfg.authURL() + "?" + q.Encode()
+}
+
+// newCallbackHandler returns a one-shot handler that serves only /callback with
+// the expected state. The first valid request delivers its code on the returned
+// channel; every other request (wrong path, wrong/missing state, or any request
+// after the first valid one) gets an error status and delivers nothing.
+func newCallbackHandler(state string) (http.Handler, <-chan string) {
+	codeCh := make(chan string, 1)
+
+	// http.Server may run handlers concurrently, so claiming the one-shot must be
+	// atomic: without the mutex two simultaneous callbacks could both pass the
+	// check and the second send would block a server goroutine forever.
+	var mu sync.Mutex
+	var delivered bool
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("state") != state {
+			http.Error(w, "invalid state", http.StatusBadRequest)
+			return
+		}
+		code := r.URL.Query().Get("code")
+		if code == "" {
+			http.Error(w, "missing code", http.StatusBadRequest)
+			return
+		}
+
+		mu.Lock()
+		alreadyDelivered := delivered
+		delivered = true
+		mu.Unlock()
+
+		if alreadyDelivered {
+			http.Error(w, "sign-in already completed", http.StatusGone)
+			return
+		}
+		codeCh <- code
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		io.WriteString(w, callbackPage)
+	})
+
+	return mux, codeCh
+}
+
+const callbackPage = `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>Signed in</title></head>
+<body style="font-family:-apple-system,sans-serif;text-align:center;padding-top:4rem">
+<h2>You're signed in.</h2>
+<p>You can close this tab and return to the app.</p>
+</body></html>`
+
+// tokenResponse mirrors the JSON returned by Google's token endpoint.
+type tokenResponse struct {
+	IDToken      string `json:"id_token"`
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int    `json:"expires_in"`
+	Error        string `json:"error"`
+	ErrorDesc    string `json:"error_description"`
+}
+
+// exchangeCode exchanges an authorization code for tokens at the token endpoint.
+// It is separated from SignIn so it can be unit-tested against an httptest
+// server without a browser.
+func exchangeCode(ctx context.Context, cfg Config, code, verifier, redirectURI string) (*Result, error) {
+	form := url.Values{}
+	form.Set("code", code)
+	form.Set("code_verifier", verifier)
+	form.Set("client_id", cfg.ClientID)
+	if cfg.ClientSecret != "" {
+		form.Set("client_secret", cfg.ClientSecret)
+	}
+	form.Set("redirect_uri", redirectURI)
+	form.Set("grant_type", "authorization_code")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.tokenURL(),
+		strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("googleauth: building token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("googleauth: token request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("googleauth: reading token response: %w", err)
+	}
+
+	var tr tokenResponse
+	if err := json.Unmarshal(body, &tr); err != nil {
+		return nil, fmt.Errorf("googleauth: parsing token response (status %d): %w", resp.StatusCode, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		if tr.Error != "" {
+			return nil, fmt.Errorf("googleauth: token exchange failed (status %d): %s: %s", resp.StatusCode, tr.Error, tr.ErrorDesc)
+		}
+		return nil, fmt.Errorf("googleauth: token exchange failed (status %d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	result := &Result{
+		IDToken:      tr.IDToken,
+		AccessToken:  tr.AccessToken,
+		RefreshToken: tr.RefreshToken,
+	}
+	if tr.ExpiresIn > 0 {
+		result.Expiry = time.Now().Add(time.Duration(tr.ExpiresIn) * time.Second)
+	}
+	if tr.IDToken != "" {
+		// Extract email from the ID token payload. The signature is NOT verified
+		// here — that is the backend's responsibility.
+		if email, err := emailFromIDToken(tr.IDToken); err == nil {
+			result.Email = email
+		}
+	}
+
+	return result, nil
+}
+
+// emailFromIDToken base64url-decodes the payload (middle) segment of a JWT and
+// extracts the "email" claim. It does not verify the signature.
+func emailFromIDToken(idToken string) (string, error) {
+	parts := strings.Split(idToken, ".")
+	if len(parts) != 3 {
+		return "", fmt.Errorf("googleauth: malformed id_token: expected 3 segments, got %d", len(parts))
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("googleauth: decoding id_token payload: %w", err)
+	}
+	var claims struct {
+		Email string `json:"email"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", fmt.Errorf("googleauth: parsing id_token claims: %w", err)
+	}
+	return claims.Email, nil
+}
+
+// generateCodeVerifier returns a high-entropy PKCE code verifier. RFC 7636
+// permits 43–128 characters from the unreserved set; base64url encoding 64
+// random bytes yields 86 characters, well within range.
+func generateCodeVerifier() (string, error) {
+	b := make([]byte, 64)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// codeChallenge computes the S256 PKCE challenge: base64url(sha256(verifier)),
+// no padding.
+func codeChallenge(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+// randomState returns a random opaque state value for CSRF protection.
+func randomState() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}

--- a/googleauth/googleauth_test.go
+++ b/googleauth/googleauth_test.go
@@ -1,0 +1,445 @@
+package googleauth
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestGenerateCodeVerifier(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		v, err := generateCodeVerifier()
+		if err != nil {
+			t.Fatalf("generateCodeVerifier: %v", err)
+		}
+		// RFC 7636 requires 43–128 characters.
+		if len(v) < 43 || len(v) > 128 {
+			t.Fatalf("verifier length %d out of range [43,128]", len(v))
+		}
+		// base64.RawURLEncoding must round-trip (unreserved chars only).
+		if _, err := base64.RawURLEncoding.DecodeString(v); err != nil {
+			t.Fatalf("verifier not valid base64url: %v", err)
+		}
+	}
+}
+
+func TestCodeChallenge(t *testing.T) {
+	tests := []string{
+		"dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+		"short-verifier-value",
+		generateOrFatal(t),
+	}
+	for _, verifier := range tests {
+		sum := sha256.Sum256([]byte(verifier))
+		want := base64.RawURLEncoding.EncodeToString(sum[:])
+		if got := codeChallenge(verifier); got != want {
+			t.Fatalf("codeChallenge(%q) = %q, want %q", verifier, got, want)
+		}
+		// No padding must be present.
+		if strings.Contains(codeChallenge(verifier), "=") {
+			t.Fatalf("codeChallenge contains padding")
+		}
+	}
+}
+
+func generateOrFatal(t *testing.T) string {
+	t.Helper()
+	v, err := generateCodeVerifier()
+	if err != nil {
+		t.Fatalf("generateCodeVerifier: %v", err)
+	}
+	return v
+}
+
+func TestRandomState(t *testing.T) {
+	seen := map[string]bool{}
+	for i := 0; i < 1000; i++ {
+		s, err := randomState()
+		if err != nil {
+			t.Fatalf("randomState: %v", err)
+		}
+		if len(s) < 32 {
+			t.Fatalf("state too short: %d chars", len(s))
+		}
+		if seen[s] {
+			t.Fatalf("duplicate state generated: %q", s)
+		}
+		seen[s] = true
+	}
+}
+
+func TestCallbackHandler(t *testing.T) {
+	const state = "expected-state-value"
+
+	tests := []struct {
+		name       string
+		path       string
+		wantStatus int
+		wantCode   string // non-empty means we expect delivery on the channel
+	}{
+		{"correct state and code", "/callback?state=expected-state-value&code=abc123", http.StatusOK, "abc123"},
+		{"wrong state", "/callback?state=nope&code=abc123", http.StatusBadRequest, ""},
+		{"missing state", "/callback?code=abc123", http.StatusBadRequest, ""},
+		{"missing code", "/callback?state=expected-state-value", http.StatusBadRequest, ""},
+		{"wrong path", "/somewhere-else?state=expected-state-value&code=abc123", http.StatusNotFound, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, codeCh := newCallbackHandler(state)
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", rec.Code, tt.wantStatus)
+			}
+			select {
+			case got := <-codeCh:
+				if tt.wantCode == "" {
+					t.Fatalf("unexpected code delivered: %q", got)
+				}
+				if got != tt.wantCode {
+					t.Fatalf("code = %q, want %q", got, tt.wantCode)
+				}
+			default:
+				if tt.wantCode != "" {
+					t.Fatalf("expected code %q, none delivered", tt.wantCode)
+				}
+			}
+		})
+	}
+}
+
+func TestCallbackHandlerOneShot(t *testing.T) {
+	const state = "one-shot-state"
+	handler, codeCh := newCallbackHandler(state)
+
+	// First valid hit captures the code.
+	rec1 := httptest.NewRecorder()
+	handler.ServeHTTP(rec1, httptest.NewRequest(http.MethodGet, "/callback?state=one-shot-state&code=first", nil))
+	if rec1.Code != http.StatusOK {
+		t.Fatalf("first request status = %d, want 200", rec1.Code)
+	}
+	if got := <-codeCh; got != "first" {
+		t.Fatalf("first code = %q, want %q", got, "first")
+	}
+
+	// Second valid request is not served (410 Gone) and delivers nothing.
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, httptest.NewRequest(http.MethodGet, "/callback?state=one-shot-state&code=second", nil))
+	if rec2.Code != http.StatusGone {
+		t.Fatalf("second request status = %d, want 410", rec2.Code)
+	}
+	select {
+	case got := <-codeCh:
+		t.Fatalf("second request should deliver nothing, got %q", got)
+	default:
+	}
+}
+
+// TestCallbackHandlerConcurrent hammers the handler with simultaneous valid
+// callbacks: exactly one must win, and no handler goroutine may block.
+func TestCallbackHandlerConcurrent(t *testing.T) {
+	const state = "concurrent-state"
+	handler, codeCh := newCallbackHandler(state)
+
+	const n = 20
+	var wg sync.WaitGroup
+	statuses := make([]int, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
+				"/callback?state=concurrent-state&code=code-"+strconv.Itoa(i), nil))
+			statuses[i] = rec.Code
+		}(i)
+	}
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler goroutines blocked; one-shot claim is not atomic")
+	}
+
+	okCount := 0
+	for _, s := range statuses {
+		switch s {
+		case http.StatusOK:
+			okCount++
+		case http.StatusGone:
+		default:
+			t.Fatalf("unexpected status %d", s)
+		}
+	}
+	if okCount != 1 {
+		t.Fatalf("expected exactly one 200, got %d", okCount)
+	}
+	if len(codeCh) != 1 {
+		t.Fatalf("expected exactly one code delivered, got %d", len(codeCh))
+	}
+}
+
+// makeIDToken builds an unsigned JWT with the given email claim.
+func makeIDToken(t *testing.T, email string) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	payloadJSON, err := json.Marshal(map[string]interface{}{
+		"email": email,
+		"sub":   "1234567890",
+		"iss":   "https://accounts.google.com",
+	})
+	if err != nil {
+		t.Fatalf("marshaling payload: %v", err)
+	}
+	payload := base64.RawURLEncoding.EncodeToString(payloadJSON)
+	return header + "." + payload + ".signature-not-verified"
+}
+
+func TestEmailFromIDToken(t *testing.T) {
+	tok := makeIDToken(t, "alice@example.com")
+	got, err := emailFromIDToken(tok)
+	if err != nil {
+		t.Fatalf("emailFromIDToken: %v", err)
+	}
+	if got != "alice@example.com" {
+		t.Fatalf("email = %q, want %q", got, "alice@example.com")
+	}
+
+	if _, err := emailFromIDToken("not.a.valid.jwt.token"); err == nil {
+		t.Fatal("expected error for malformed token, got nil")
+	}
+	if _, err := emailFromIDToken("onlyonesegment"); err == nil {
+		t.Fatal("expected error for single-segment token, got nil")
+	}
+}
+
+func TestExchangeCode(t *testing.T) {
+	const (
+		wantCode     = "auth-code-xyz"
+		wantVerifier = "the-code-verifier"
+		wantClientID = "client-123.apps.googleusercontent.com"
+		wantSecret   = "secret-abc"
+		redirectURI  = "http://127.0.0.1:5000/callback"
+	)
+	idToken := makeIDToken(t, "bob@example.com")
+
+	t.Run("success", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if err := r.ParseForm(); err != nil {
+				t.Errorf("ParseForm: %v", err)
+			}
+			checks := map[string]string{
+				"code":          wantCode,
+				"code_verifier": wantVerifier,
+				"client_id":     wantClientID,
+				"client_secret": wantSecret,
+				"redirect_uri":  redirectURI,
+				"grant_type":    "authorization_code",
+			}
+			for k, want := range checks {
+				if got := r.PostForm.Get(k); got != want {
+					t.Errorf("form[%s] = %q, want %q", k, got, want)
+				}
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"id_token":      idToken,
+				"access_token":  "access-tok",
+				"refresh_token": "refresh-tok",
+				"expires_in":    3600,
+			})
+		}))
+		defer srv.Close()
+
+		cfg := Config{ClientID: wantClientID, ClientSecret: wantSecret, TokenURL: srv.URL}
+		res, err := exchangeCode(context.Background(), cfg, wantCode, wantVerifier, redirectURI)
+		if err != nil {
+			t.Fatalf("exchangeCode: %v", err)
+		}
+		if res.AccessToken != "access-tok" {
+			t.Errorf("AccessToken = %q", res.AccessToken)
+		}
+		if res.RefreshToken != "refresh-tok" {
+			t.Errorf("RefreshToken = %q", res.RefreshToken)
+		}
+		if res.IDToken != idToken {
+			t.Errorf("IDToken mismatch")
+		}
+		if res.Email != "bob@example.com" {
+			t.Errorf("Email = %q, want bob@example.com", res.Email)
+		}
+		if res.Expiry.IsZero() {
+			t.Errorf("Expiry not set")
+		}
+		if d := time.Until(res.Expiry); d < 55*time.Minute || d > 65*time.Minute {
+			t.Errorf("Expiry ~1h off: %v", d)
+		}
+	})
+
+	t.Run("no client secret omits it", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			r.ParseForm()
+			if _, present := r.PostForm["client_secret"]; present {
+				t.Errorf("client_secret should be absent when unset")
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{"id_token": idToken, "access_token": "a", "expires_in": 10})
+		}))
+		defer srv.Close()
+
+		cfg := Config{ClientID: wantClientID, TokenURL: srv.URL}
+		if _, err := exchangeCode(context.Background(), cfg, wantCode, wantVerifier, redirectURI); err != nil {
+			t.Fatalf("exchangeCode: %v", err)
+		}
+	})
+
+	t.Run("non-200 is an error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"error":             "invalid_grant",
+				"error_description": "code expired",
+			})
+		}))
+		defer srv.Close()
+
+		cfg := Config{ClientID: wantClientID, TokenURL: srv.URL}
+		_, err := exchangeCode(context.Background(), cfg, wantCode, wantVerifier, redirectURI)
+		if err == nil {
+			t.Fatal("expected error for non-200 response, got nil")
+		}
+		if !strings.Contains(err.Error(), "invalid_grant") {
+			t.Errorf("error should mention the Google error code: %v", err)
+		}
+	})
+}
+
+func TestBuildAuthURL(t *testing.T) {
+	cfg := Config{
+		ClientID: "cid",
+		Scopes:   []string{"openid", "email", "profile"},
+	}
+	raw := buildAuthURL(cfg, "http://127.0.0.1:1234/callback", "the-challenge", "the-state")
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse auth url: %v", err)
+	}
+	if got, want := u.Scheme+"://"+u.Host+u.Path, defaultAuthURL; got != want {
+		t.Fatalf("auth endpoint = %q, want %q", got, want)
+	}
+	q := u.Query()
+	want := map[string]string{
+		"client_id":             "cid",
+		"redirect_uri":          "http://127.0.0.1:1234/callback",
+		"response_type":         "code",
+		"scope":                 "openid email profile",
+		"code_challenge":        "the-challenge",
+		"code_challenge_method": "S256",
+		"state":                 "the-state",
+		"access_type":           "offline",
+		"prompt":                "select_account",
+	}
+	for k, v := range want {
+		if got := q.Get(k); got != v {
+			t.Errorf("query[%s] = %q, want %q", k, got, v)
+		}
+	}
+}
+
+// TestSignInHappyPath drives the whole flow with OpenURL injected to act as the
+// browser (it hits the local callback), and TokenURL pointed at an httptest
+// server. No real browser, no network.
+func TestSignInHappyPath(t *testing.T) {
+	idToken := makeIDToken(t, "carol@example.com")
+
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"id_token":      idToken,
+			"access_token":  "access-tok",
+			"refresh_token": "refresh-tok",
+			"expires_in":    3600,
+		})
+	}))
+	defer tokenSrv.Close()
+
+	// The injected "browser" parses the auth URL, extracts redirect_uri + state,
+	// and calls the callback exactly as Google would after consent.
+	openURL := func(authURL string) error {
+		u, err := url.Parse(authURL)
+		if err != nil {
+			return err
+		}
+		q := u.Query()
+		cb := q.Get("redirect_uri") + "?state=" + url.QueryEscape(q.Get("state")) + "&code=fake-auth-code"
+		go func() {
+			resp, err := http.Get(cb)
+			if err == nil {
+				resp.Body.Close()
+			}
+		}()
+		return nil
+	}
+
+	cfg := Config{
+		ClientID: "cid",
+		Scopes:   []string{"openid", "email"},
+		TokenURL: tokenSrv.URL,
+		OpenURL:  openURL,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	res, err := SignIn(ctx, cfg)
+	if err != nil {
+		t.Fatalf("SignIn: %v", err)
+	}
+	if res.Email != "carol@example.com" {
+		t.Errorf("Email = %q, want carol@example.com", res.Email)
+	}
+	if res.AccessToken != "access-tok" || res.RefreshToken != "refresh-tok" {
+		t.Errorf("tokens missing: %+v", res)
+	}
+}
+
+func TestSignInRequiresClientID(t *testing.T) {
+	_, err := SignIn(context.Background(), Config{})
+	if err == nil {
+		t.Fatal("expected error when ClientID is empty")
+	}
+}
+
+func TestSignInContextCancelled(t *testing.T) {
+	// OpenURL that never triggers a callback → SignIn must give up on ctx.
+	cfg := Config{
+		ClientID: "cid",
+		OpenURL:  func(string) error { return nil },
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := SignIn(ctx, cfg)
+	if err == nil {
+		t.Fatal("expected context deadline error")
+	}
+	if time.Since(start) > 2*time.Second {
+		t.Fatalf("SignIn took too long to honor ctx: %v", time.Since(start))
+	}
+}


### PR DESCRIPTION
Adds `googleauth`, a subpackage implementing the OAuth 2.0 **loopback redirect + PKCE** native-app flow — the Apple/Google-recommended way for a desktop app to sign a user in with Google (no embedded webview, no confidential client secret).

Any menuet app can use it by supplying its own Google "Desktop app" OAuth client ID and scopes.

## Public API

```go
type Config struct {
    ClientID     string             // Google "Desktop app" OAuth client ID (required)
    ClientSecret string             // optional; PKCE is the real gate
    Scopes       []string           // e.g. {"openid","email","profile"}
    AuthURL      string             // optional override
    TokenURL     string             // optional override
    OpenURL      func(string) error // optional; defaults to `open <url>`
}

type Result struct {
    IDToken      string // JWT — send to your backend to verify identity
    AccessToken  string
    RefreshToken string
    Email        string
    Expiry       time.Time
}

func SignIn(ctx context.Context, cfg Config) (*Result, error)
```

`SignIn` blocks until the browser redirect lands, so call it off the UI goroutine.

## Stdlib only

No `golang.org/x/oauth2`, **no new go.mod dependencies**, and it imports nothing from the menuet root package — `net/http`, `crypto/*`, `encoding/*`, `os/exec` only. The subpackage placement keeps the core lean and makes "reusable" literal.

## Hardening

- **PKCE (S256)** — `code_verifier` from `crypto/rand` (86 chars, inside RFC 7636's 43–128), `code_challenge` = base64url-no-pad(sha256(verifier)).
- **State** — 256 bits of `crypto/rand`, verified on the callback; wrong or missing state is rejected.
- **Loopback binding** — `net.Listen("tcp", "127.0.0.1:0")` binds 127.0.0.1 explicitly (never `0.0.0.0`) on an ephemeral port.
- **One-shot callback server** — serves *only* `/callback` with the expected state, accepts the first valid hit and returns `410 Gone` to any subsequent one; 404s everything else. The one-shot claim is mutex-guarded because `http.Server` runs handlers concurrently — without it, two simultaneous callbacks could both pass the check and the second send would deadlock a server goroutine. There's a `-race` test for exactly this.
- **Timeout** — respects the caller's context; applies a 3-minute deadline when the context has none, so a user who abandons the browser doesn't leak the listener.

## ID token handling

The `id_token` signature is **deliberately not verified** client-side — that's the backend's job. The client only base64url-decodes the payload segment to surface the `email` claim for display.

## Residual risk (inherent, documented in the package doc)

Any local application can initiate this flow using the extractable desktop client ID; the browser consent step is the only gate. This is inherent to native-app OAuth, not a flaw in this package.

## Tests

Table-driven, stdlib + `httptest` only — no network, no real browser. `exchangeCode` is factored out as a separately-callable function so it can be tested against an `httptest.Server` standing in for the token endpoint; the `SignIn` happy path injects `OpenURL` to play the browser and hit the local callback itself.

Covers: PKCE challenge/verifier, state randomness, callback state validation + one-shot semantics (including the concurrent race), token exchange success / non-200 / client-secret omission, email extraction from a hand-built unsigned JWT, the full `SignIn` happy path, and context cancellation.

```
go build ./...                  ok
go vet ./...                    ok
go test ./googleauth/           ok
go test -race ./googleauth/     ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)