### PR TITLE
googleauth: identity-only default; offline access as explicit opt-in

### DIFF
--- a/googleauth/googleauth.go
+++ b/googleauth/googleauth.go
@@ -79,14 +79,21 @@ type Config struct {
 	// At least one is required.
 	Scopes []string
 
-	// Prompt sets Google's prompt parameter. Defaults to "select_account".
+	// Offline requests offline access — a RefreshToken usable to call Google
+	// APIs on the user's behalf when they are not present. Defaults to false:
+	// most sign-in flows only need identity (verify the IDToken and you know
+	// who the user is), and a refresh token is a powerful long-lived credential
+	// you'd otherwise have to store and protect for no reason.
 	//
-	// If your app needs a RefreshToken for offline access, set this to
-	// "consent": Google issues a refresh token only on the first consent for an
-	// account, so under the "select_account" default a repeat sign-in of an
-	// already-consented account returns an empty RefreshToken. "consent"
-	// re-shows the consent screen every time, so only use it when you actually
-	// store and use the refresh token.
+	// When true, this also forces prompt=consent, because Google issues a
+	// refresh token only on the first consent for an account — under the normal
+	// "select_account" prompt a repeat sign-in returns an empty RefreshToken.
+	// Tying the two together means you can't accidentally ask for offline
+	// access and silently not get a refresh token. Set Prompt to override.
+	Offline bool
+
+	// Prompt overrides Google's prompt parameter. Defaults to "select_account",
+	// or "consent" when Offline is true.
 	Prompt string
 
 	// AuthURL optionally overrides the Google authorization endpoint.
@@ -105,7 +112,7 @@ type Config struct {
 type Result struct {
 	IDToken      string // JWT — send to your backend to verify identity.
 	AccessToken  string
-	RefreshToken string
+	RefreshToken string // empty unless Config.Offline was set.
 	Email        string
 	Expiry       time.Time
 
@@ -140,6 +147,10 @@ func (c Config) openURL() func(string) error {
 func (c Config) prompt() string {
 	if c.Prompt != "" {
 		return c.Prompt
+	}
+	if c.Offline {
+		// Only "consent" reliably yields a refresh token on repeat sign-ins.
+		return "consent"
 	}
 	return "select_account"
 }
@@ -252,7 +263,9 @@ func buildAuthURL(cfg Config, redirectURI, challenge, state, nonce string) strin
 	q.Set("code_challenge_method", "S256")
 	q.Set("state", state)
 	q.Set("nonce", nonce)
-	q.Set("access_type", "offline")
+	if cfg.Offline {
+		q.Set("access_type", "offline")
+	}
 	q.Set("prompt", cfg.prompt())
 	return cfg.authURL() + "?" + q.Encode()
 }

--- a/googleauth/googleauth_test.go
+++ b/googleauth/googleauth_test.go
@@ -395,13 +395,17 @@ func TestBuildAuthURL(t *testing.T) {
 		"code_challenge_method": "S256",
 		"state":                 "the-state",
 		"nonce":                 "the-nonce",
-		"access_type":           "offline",
 		"prompt":                "select_account",
 	}
 	for k, v := range want {
 		if got := q.Get(k); got != v {
 			t.Errorf("query[%s] = %q, want %q", k, got, v)
 		}
+	}
+	// The default is identity-only: no offline access is requested, so no
+	// refresh token is issued and there is nothing long-lived to store.
+	if _, ok := q["access_type"]; ok {
+		t.Errorf("default must not request access_type=offline, got %q", q.Get("access_type"))
 	}
 }
 
@@ -414,6 +418,41 @@ func TestBuildAuthURLPromptOverride(t *testing.T) {
 	}
 	if got := u.Query().Get("prompt"); got != "consent" {
 		t.Errorf("prompt = %q, want consent", got)
+	}
+}
+
+func TestBuildAuthURLOffline(t *testing.T) {
+	// Offline opt-in must set access_type=offline AND force prompt=consent, so
+	// Google reliably returns a refresh token (select_account only issues one on
+	// first consent). The two flags travel together — the caller can't land in
+	// the incoherent offline+select_account middle.
+	cfg := Config{ClientID: "cid", Scopes: []string{"openid"}, Offline: true}
+	raw := buildAuthURL(cfg, "http://127.0.0.1:1/callback", "c", "s", "n")
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse auth url: %v", err)
+	}
+	q := u.Query()
+	if got := q.Get("access_type"); got != "offline" {
+		t.Errorf("access_type = %q, want offline", got)
+	}
+	if got := q.Get("prompt"); got != "consent" {
+		t.Errorf("prompt = %q, want consent when Offline", got)
+	}
+}
+
+func TestBuildAuthURLOfflinePromptStillOverridable(t *testing.T) {
+	// An explicit Prompt wins even with Offline, for callers who know what they
+	// want (e.g. offline access without re-consent on every sign-in).
+	cfg := Config{ClientID: "cid", Scopes: []string{"openid"}, Offline: true, Prompt: "select_account"}
+	raw := buildAuthURL(cfg, "http://127.0.0.1:1/callback", "c", "s", "n")
+	u, _ := url.Parse(raw)
+	q := u.Query()
+	if got := q.Get("access_type"); got != "offline" {
+		t.Errorf("access_type = %q, want offline", got)
+	}
+	if got := q.Get("prompt"); got != "select_account" {
+		t.Errorf("prompt = %q, want select_account (explicit override)", got)
 	}
 }
 


### PR DESCRIPTION
Resolves the F2 finding from the #51 review.

The default paired `access_type=offline` with `prompt=select_account` — requesting a refresh token via the one prompt mode that only reliably issues one on *first* consent, so repeat sign-ins silently returned an empty `RefreshToken`.

## Change

- **Default is now identity-only** — no `access_type=offline`. Verify the `id_token`, know the user, done. No long-lived refresh token to store.
- **`Config.Offline bool`** opts into offline access and sets `access_type=offline` **and** `prompt=consent` together, so you can't accidentally be in the incoherent middle.
- `Config.Prompt` still overrides.

## Why identity-only is the right default

The one real consumer, wishy-watchy's menubar, is explicitly identity-only — `oauth.ts`: *"We do NOT store Google access or refresh tokens — we only need who are you at login time."* It signs in to get an `id_token`, POSTs it to the backend, which verifies signature/`aud`/allowlist and mints its own API token.

## Not adopting x/oauth2

Its main value is refresh handling, which identity-only flows don't use — so googleauth stays stdlib-only.

## Test plan
- [x] `go test -race ./googleauth/` — default asserts no `access_type`; `Offline` asserts `offline`+`consent`; explicit prompt still overrides
- [x] `go vet`, `GOOS=linux`/`windows` builds