### PR TITLE
googleauth: callback page reflects the real exchange outcome (F5)

### DIFF
--- a/googleauth/googleauth.go
+++ b/googleauth/googleauth.go
@@ -217,7 +217,22 @@ func SignIn(ctx context.Context, cfg Config) (*Result, error) {
 	port := listener.Addr().(*net.TCPAddr).Port
 	redirectURI := fmt.Sprintf("http://127.0.0.1:%d/callback", port)
 
-	handler, resultCh := newCallbackHandler(state)
+	// The exchange runs inside the callback handler (below) so the page the
+	// browser sees reflects the true outcome — a failed exchange shows the
+	// failure page, not an optimistic "signed in". It gets its own budget,
+	// decoupled from the human-paced consent wait.
+	exchange := func(code string) (*Result, error) {
+		exchangeCtx, cancel := context.WithTimeout(context.Background(), exchangeTimeout)
+		defer cancel()
+		result, err := exchangeCode(exchangeCtx, cfg, code, verifier, redirectURI)
+		if err != nil {
+			return nil, err
+		}
+		result.Nonce = nonce
+		return result, nil
+	}
+
+	handler, resultCh := newCallbackHandler(state, exchange)
 	server := &http.Server{Handler: handler}
 	go server.Serve(listener)
 	// Shutdown (not Close) lets an in-flight callback finish writing its page to
@@ -237,18 +252,7 @@ func SignIn(ctx context.Context, cfg Config) (*Result, error) {
 	case <-ctx.Done():
 		return nil, fmt.Errorf("googleauth: waiting for callback: %w", ctx.Err())
 	case res := <-resultCh:
-		if res.err != nil {
-			return nil, fmt.Errorf("googleauth: sign-in failed: %w", res.err)
-		}
-		// Give the exchange its own budget, decoupled from the consent wait.
-		exchangeCtx, cancel := context.WithTimeout(context.Background(), exchangeTimeout)
-		defer cancel()
-		result, err := exchangeCode(exchangeCtx, cfg, res.code, verifier, redirectURI)
-		if err != nil {
-			return nil, err
-		}
-		result.Nonce = nonce
-		return result, nil
+		return res.result, res.err
 	}
 }
 
@@ -270,20 +274,26 @@ func buildAuthURL(cfg Config, redirectURI, challenge, state, nonce string) strin
 	return cfg.authURL() + "?" + q.Encode()
 }
 
-// callbackResult is what a valid /callback delivers: either an authorization
-// code, or an err when Google reported an OAuth error (e.g. the user declined).
+// callbackResult is the sign-in's terminal outcome, delivered once: either a
+// completed Result (code received and exchanged for tokens) or an err (the user
+// declined consent, or the exchange failed).
 type callbackResult struct {
-	code string
-	err  error
+	result *Result
+	err    error
 }
 
+// exchangeFunc turns an authorization code into a Result. The handler calls it
+// before rendering, so the page the browser sees matches the real outcome.
+type exchangeFunc func(code string) (*Result, error)
+
 // newCallbackHandler returns a one-shot handler that serves only /callback with
-// the expected state. The first valid request delivers a callbackResult on the
-// returned channel; every other request (wrong path, wrong/missing state, or
-// any request after the first valid one) gets an error status and delivers
-// nothing. A callback carrying an OAuth error (rather than a code) is a valid,
-// terminal outcome — it claims the one-shot and delivers an *AuthError.
-func newCallbackHandler(state string) (http.Handler, <-chan callbackResult) {
+// the expected state. On the first valid request it runs exchange, renders the
+// matching page, and delivers the outcome on the returned channel; every other
+// request (wrong path, wrong/missing state, or any request after the first
+// valid one) gets an error status and delivers nothing. A callback carrying an
+// OAuth error (rather than a code) is a valid, terminal outcome — it claims the
+// one-shot and delivers an *AuthError without running exchange.
+func newCallbackHandler(state string, exchange exchangeFunc) (http.Handler, <-chan callbackResult) {
 	resultCh := make(chan callbackResult, 1)
 
 	// http.Server may run handlers concurrently, so claiming the one-shot must be
@@ -319,18 +329,32 @@ func newCallbackHandler(state string) (http.Handler, <-chan callbackResult) {
 		}
 
 		if oauthErr != "" {
-			resultCh <- callbackResult{err: &AuthError{Code: oauthErr, Description: q.Get("error_description")}}
-			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			io.WriteString(w, failurePage)
+			renderCallbackPage(w, false)
+			resultCh <- callbackResult{err: fmt.Errorf("googleauth: sign-in failed: %w",
+				&AuthError{Code: oauthErr, Description: q.Get("error_description")})}
 			return
 		}
 
-		resultCh <- callbackResult{code: code}
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		io.WriteString(w, callbackPage)
+		// Exchange first, then render the page that matches the outcome — the
+		// browser must not claim success if the exchange failed. Render before
+		// delivering so the page is written while this handler is still active
+		// and the deferred server.Shutdown waits for it to flush.
+		result, err := exchange(code)
+		renderCallbackPage(w, err == nil)
+		resultCh <- callbackResult{result: result, err: err}
 	})
 
 	return mux, resultCh
+}
+
+// renderCallbackPage writes the success or failure page to the browser.
+func renderCallbackPage(w http.ResponseWriter, ok bool) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if ok {
+		io.WriteString(w, callbackPage)
+	} else {
+		io.WriteString(w, failurePage)
+	}
 }
 
 const callbackPage = `<!DOCTYPE html>

--- a/googleauth/googleauth_test.go
+++ b/googleauth/googleauth_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -81,12 +82,18 @@ func TestRandomState(t *testing.T) {
 func TestCallbackHandler(t *testing.T) {
 	const state = "expected-state-value"
 
+	// Injected exchange echoes the code into the Result so the test can assert
+	// it flowed through (and that exchange ran at all).
+	exchange := func(code string) (*Result, error) {
+		return &Result{AccessToken: "exchanged:" + code}, nil
+	}
+
 	tests := []struct {
 		name       string
 		path       string
 		wantStatus int
-		wantCode   string // non-empty means we expect a code delivered
-		wantErr    bool   // true means we expect an error result delivered
+		wantCode   string // non-empty: expect a Result whose token carries this code
+		wantErr    bool   // true: expect an error result delivered
 	}{
 		{"correct state and code", "/callback?state=expected-state-value&code=abc123", http.StatusOK, "abc123", false},
 		{"oauth error redirect", "/callback?state=expected-state-value&error=access_denied&error_description=denied", http.StatusOK, "", true},
@@ -98,7 +105,7 @@ func TestCallbackHandler(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handler, resultCh := newCallbackHandler(state)
+			handler, resultCh := newCallbackHandler(state, exchange)
 			rec := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
 			handler.ServeHTTP(rec, req)
@@ -111,12 +118,12 @@ func TestCallbackHandler(t *testing.T) {
 				switch {
 				case tt.wantErr:
 					if got.err == nil {
-						t.Fatalf("expected error result, got code %q", got.code)
+						t.Fatalf("expected error result, got %+v", got.result)
 					}
 				case tt.wantCode == "":
 					t.Fatalf("unexpected result delivered: %+v", got)
-				case got.code != tt.wantCode:
-					t.Fatalf("code = %q, want %q", got.code, tt.wantCode)
+				case got.result == nil || got.result.AccessToken != "exchanged:"+tt.wantCode:
+					t.Fatalf("result = %+v, want token exchanged:%s", got.result, tt.wantCode)
 				}
 			default:
 				if tt.wantCode != "" || tt.wantErr {
@@ -129,16 +136,17 @@ func TestCallbackHandler(t *testing.T) {
 
 func TestCallbackHandlerOneShot(t *testing.T) {
 	const state = "one-shot-state"
-	handler, resultCh := newCallbackHandler(state)
+	exchange := func(code string) (*Result, error) { return &Result{AccessToken: code}, nil }
+	handler, resultCh := newCallbackHandler(state, exchange)
 
-	// First valid hit captures the code.
+	// First valid hit runs the exchange and delivers the result.
 	rec1 := httptest.NewRecorder()
 	handler.ServeHTTP(rec1, httptest.NewRequest(http.MethodGet, "/callback?state=one-shot-state&code=first", nil))
 	if rec1.Code != http.StatusOK {
 		t.Fatalf("first request status = %d, want 200", rec1.Code)
 	}
-	if got := <-resultCh; got.code != "first" {
-		t.Fatalf("first code = %q, want %q", got.code, "first")
+	if got := <-resultCh; got.result == nil || got.result.AccessToken != "first" {
+		t.Fatalf("first result = %+v, want token first", got.result)
 	}
 
 	// Second valid request is not served (410 Gone) and delivers nothing.
@@ -158,7 +166,9 @@ func TestCallbackHandlerOneShot(t *testing.T) {
 // callbacks: exactly one must win, and no handler goroutine may block.
 func TestCallbackHandlerConcurrent(t *testing.T) {
 	const state = "concurrent-state"
-	handler, resultCh := newCallbackHandler(state)
+	handler, resultCh := newCallbackHandler(state, func(code string) (*Result, error) {
+		return &Result{AccessToken: code}, nil
+	})
 
 	const n = 20
 	var wg sync.WaitGroup
@@ -520,6 +530,62 @@ func TestSignInHappyPath(t *testing.T) {
 	}
 	if res.Nonce != sentNonce {
 		t.Errorf("Result.Nonce = %q, want %q (the nonce sent to Google)", res.Nonce, sentNonce)
+	}
+}
+
+// TestSignInExchangeFailureRendersFailurePage is the F5 regression: when the
+// token exchange fails after a valid redirect, the browser must see the failure
+// page, not an optimistic "You're signed in."
+func TestSignInExchangeFailureRendersFailurePage(t *testing.T) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"error":             "invalid_grant",
+			"error_description": "code expired",
+		})
+	}))
+	defer tokenSrv.Close()
+
+	pageCh := make(chan string, 1)
+	openURL := func(authURL string) error {
+		u, err := url.Parse(authURL)
+		if err != nil {
+			return err
+		}
+		q := u.Query()
+		cb := q.Get("redirect_uri") + "?state=" + url.QueryEscape(q.Get("state")) + "&code=fake-auth-code"
+		go func() {
+			resp, err := http.Get(cb)
+			if err != nil {
+				pageCh <- "GET error: " + err.Error()
+				return
+			}
+			defer resp.Body.Close()
+			body, _ := io.ReadAll(resp.Body)
+			pageCh <- string(body)
+		}()
+		return nil
+	}
+
+	cfg := Config{ClientID: "cid", Scopes: []string{"openid"}, TokenURL: tokenSrv.URL, OpenURL: openURL}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if _, err := SignIn(ctx, cfg); err == nil {
+		t.Fatal("expected an error when the exchange fails")
+	}
+
+	select {
+	case page := <-pageCh:
+		if strings.Contains(page, "You're signed in") {
+			t.Errorf("browser shown the success page despite a failed exchange:\n%s", page)
+		}
+		if !strings.Contains(page, "didn't complete") {
+			t.Errorf("expected the failure page, got:\n%s", page)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("browser never received a page")
 	}
 }
 


### PR DESCRIPTION
Resolves the F5 finding from the #51 review.

The success page was written the moment a valid code arrived — before the token exchange ran. A subsequent exchange failure left the browser showing "You're signed in" while `SignIn` returned an error.

## Change

The exchange now runs **inside** the callback handler (via an injected `exchangeFunc`), before the page is rendered:
- exchange fails → failure page
- exchange succeeds → success page

The handler renders *before* delivering its outcome on the channel, so the page is flushed while the handler is still active and the deferred `server.Shutdown` waits for it. `callbackResult` now carries the resolved `*Result`/error, so `SignIn` just relays it. The handler stays unit-testable via an injected fake exchange.

## Test plan
- [x] New `TestSignInExchangeFailureRendersFailurePage` — asserts the browser gets the failure page, not "You're signed in" (red before, green after)
- [x] `go test -race -count=5 ./googleauth/`, `go vet`, `GOOS=linux`/`windows` builds