### PR TITLE
Add Image menu item: a row that draws a picture

### DIFF
--- a/cmd/catalog/catalog.go
+++ b/cmd/catalog/catalog.go
@@ -1,8 +1,19 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
+	"image"
+	"image/color"
+	"image/draw"
+	"image/png"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/caseymrm/menuet/v2"
 )
@@ -132,7 +143,217 @@ func menuItems() []menuet.MenuItem {
 			Text:     "Hotkeys",
 			Children: hotkeysDemo,
 		},
+		menuet.Regular{
+			Text:     "Images",
+			Children: imageDemo,
+		},
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Images
+//
+// menuet.Image is a row that draws a picture instead of text. As the only
+// child of a Regular it makes a submenu that *is* an image.
+//
+// The pictures below are generated in Go, which is also the point: menuet
+// never fetches an image itself (that would run on the thread building the
+// menu, and couldn't carry an auth header). Whatever your app can produce or
+// download — an authenticated screenshot, a chart — it hands over as Data or
+// a Path.
+// ---------------------------------------------------------------------------
+
+var (
+	chartOnce sync.Once
+	chartData []byte
+
+	shotOnce sync.Once
+	shotData []byte
+	shotPath string
+
+	imageClicks int
+)
+
+func imageDemo() []menuet.MenuItem {
+	return []menuet.MenuItem{
+		// The headline: the whole submenu is one picture.
+		menuet.Regular{
+			Text: "Submenu that is an image",
+			Children: func() []menuet.MenuItem {
+				return []menuet.MenuItem{
+					menuet.Image{Data: chartPNG(), MaxWidth: 400},
+				}
+			},
+		},
+
+		// The shape a real app usually wants: picture, caption, action.
+		menuet.Regular{
+			Text: "Picture, caption, action",
+			Children: func() []menuet.MenuItem {
+				return []menuet.MenuItem{
+					menuet.Image{Data: screenshotPNG(), MaxWidth: 480},
+					menuet.Regular{Runs: []menuet.TextRun{
+						{Text: "Captured ", Color: menuet.LabelSecondary, FontSize: 11},
+						{Text: time.Now().Format("3:04:05 PM"),
+							Color: menuet.LabelSecondary, FontSize: 11, Monospaced: true},
+					}},
+					menuet.Separator{},
+					menuet.Regular{Text: "Open full size", Clicked: openFullSize},
+				}
+			},
+		},
+
+		// Clicked makes the picture itself a button: it highlights under the
+		// pointer and dismisses the menu on click, like any other row.
+		menuet.Regular{
+			Text: "Clickable image",
+			Children: func() []menuet.MenuItem {
+				return []menuet.MenuItem{
+					menuet.Image{
+						Data:     chartPNG(),
+						MaxWidth: 320,
+						Clicked: func() {
+							imageClicks++
+							menuet.App().MenuChanged()
+						},
+					},
+					menuet.Regular{Runs: []menuet.TextRun{
+						{Text: fmt.Sprintf("Clicked %d time(s) — click the chart",
+							imageClicks), Color: menuet.LabelSecondary, FontSize: 11},
+					}},
+				}
+			},
+		},
+
+		// Path source. For a big image only the path crosses the cgo bridge,
+		// rather than ~1MB of base64 on every single menu open.
+		menuet.Regular{
+			Text: "From a file path",
+			Children: func() []menuet.MenuItem {
+				path := screenshotFilePath()
+				if path == "" {
+					return []menuet.MenuItem{
+						menuet.Regular{Text: "couldn't write the temp file"},
+					}
+				}
+				return []menuet.MenuItem{
+					menuet.Image{Path: path, MaxWidth: 480},
+					menuet.Regular{Runs: []menuet.TextRun{
+						{Text: path, Color: menuet.LabelTertiary, FontSize: 10, Monospaced: true},
+					}},
+				}
+			},
+		},
+
+		// One 1440x900 source, three bounds. It only ever scales *down* —
+		// never up — so the aspect ratio always survives.
+		menuet.Regular{
+			Text: "Scale to fit (one 1440×900 source)",
+			Children: func() []menuet.MenuItem {
+				label := func(s string) menuet.MenuItem {
+					return menuet.Regular{Runs: []menuet.TextRun{
+						{Text: s, Color: menuet.LabelSecondary, FontSize: 11, Monospaced: true},
+					}}
+				}
+				return []menuet.MenuItem{
+					label("MaxWidth: 160"),
+					menuet.Image{Data: screenshotPNG(), MaxWidth: 160},
+					label("MaxWidth: 300"),
+					menuet.Image{Data: screenshotPNG(), MaxWidth: 300},
+					label("default bound (480×360)"),
+					menuet.Image{Data: screenshotPNG()},
+				}
+			},
+		},
+	}
+}
+
+func openFullSize() {
+	if path := screenshotFilePath(); path != "" {
+		exec.Command("open", path).Run()
+	}
+}
+
+// chartPNG renders a small bar chart. Built once: Children runs on every menu
+// open, and re-encoding a PNG each time would be wasted work.
+func chartPNG() []byte {
+	chartOnce.Do(func() {
+		const w, h = 400, 160
+		img := image.NewRGBA(image.Rect(0, 0, w, h))
+		fill(img, img.Bounds(), color.RGBA{0x1c, 0x1c, 0x20, 0xff})
+		bars := []int{40, 95, 62, 130, 78, 110, 55}
+		barW := w / (len(bars)*2 + 1)
+		for i, v := range bars {
+			c := color.RGBA{0x0a, 0x84, 0xff, 0xff}
+			if v == 130 {
+				c = color.RGBA{0x30, 0xd1, 0x58, 0xff} // the peak
+			}
+			x := barW + i*2*barW
+			fill(img, image.Rect(x, h-v-12, x+barW, h-12), c)
+		}
+		chartData = encodePNG(img)
+	})
+	return chartData
+}
+
+// screenshotPNG renders a 1440x900 stand-in for a real screen capture — big
+// enough that the scale-to-fit path is doing real work.
+func screenshotPNG() []byte {
+	shotOnce.Do(buildScreenshot)
+	return shotData
+}
+
+// screenshotFilePath is the same picture on disk, for the Path source.
+func screenshotFilePath() string {
+	shotOnce.Do(buildScreenshot)
+	return shotPath
+}
+
+func buildScreenshot() {
+	const w, h = 1440, 900
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			img.SetRGBA(x, y, color.RGBA{
+				R: uint8(30 + 90*x/w),
+				G: uint8(40 + 60*y/h),
+				B: uint8(120 + 100*(w-x)/w),
+				A: 0xff,
+			})
+		}
+	}
+	// A few "windows", so the downscaled picture still reads as a screen.
+	for i, r := range []image.Rectangle{
+		image.Rect(80, 90, 700, 520),
+		image.Rect(420, 300, 1180, 780),
+		image.Rect(900, 80, 1360, 380),
+	} {
+		shade := uint8(235 - 45*i)
+		fill(img, r, color.RGBA{shade, shade, shade, 0xff})
+		fill(img, image.Rect(r.Min.X, r.Min.Y, r.Max.X, r.Min.Y+30),
+			color.RGBA{0x3a, 0x3a, 0x42, 0xff})
+	}
+	shotData = encodePNG(img)
+
+	path := filepath.Join(os.TempDir(), "menuet-catalog-screenshot.png")
+	if err := os.WriteFile(path, shotData, 0o600); err != nil {
+		log.Printf("catalog: writing demo screenshot: %v", err)
+		return
+	}
+	shotPath = path
+}
+
+func fill(img *image.RGBA, r image.Rectangle, c color.RGBA) {
+	draw.Draw(img, r, &image.Uniform{C: c}, image.Point{}, draw.Src)
+}
+
+func encodePNG(img image.Image) []byte {
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		log.Printf("catalog: encoding png: %v", err)
+		return nil
+	}
+	return buf.Bytes()
 }
 
 var hotkeyFireCount int

--- a/cmd/catalog/menuet-demo.json
+++ b/cmd/catalog/menuet-demo.json
@@ -2306,6 +2306,492 @@
           }
         }
       ]
+    },
+    {
+      "type": "regular",
+      "text": "Images",
+      "color": {
+        "R": 0,
+        "G": 0,
+        "B": 0,
+        "A": 0
+      },
+      "children": [
+        {
+          "type": "regular",
+          "text": "Submenu that is an image",
+          "color": {
+            "R": 0,
+            "G": 0,
+            "B": 0,
+            "A": 0
+          },
+          "children": [
+            {
+              "type": "image",
+              "color": {
+                "R": 0,
+                "G": 0,
+                "B": 0,
+                "A": 0
+              },
+              "imageWidth": 400,
+              "imageHeight": 360,
+              "imageSource": "data"
+            }
+          ]
+        },
+        {
+          "type": "regular",
+          "text": "Picture, caption, action",
+          "color": {
+            "R": 0,
+            "G": 0,
+            "B": 0,
+            "A": 0
+          },
+          "children": [
+            {
+              "type": "image",
+              "color": {
+                "R": 0,
+                "G": 0,
+                "B": 0,
+                "A": 0
+              },
+              "imageWidth": 480,
+              "imageHeight": 360,
+              "imageSource": "data"
+            },
+            {
+              "type": "regular",
+              "runs": [
+                {
+                  "Text": "Captured ",
+                  "Color": {
+                    "R": 0,
+                    "G": 0,
+                    "B": 0,
+                    "A": 0,
+                    "Semantic": "secondaryLabelColor"
+                  },
+                  "FontSize": 11,
+                  "FontWeight": 0,
+                  "Monospaced": false,
+                  "Badge": false,
+                  "Underline": false,
+                  "UnderlineColor": {
+                    "R": 0,
+                    "G": 0,
+                    "B": 0,
+                    "A": 0
+                  },
+                  "Strikethrough": false,
+                  "StrikethroughColor": {
+                    "R": 0,
+                    "G": 0,
+                    "B": 0,
+                    "A": 0
+                  },
+                  "Background": {
+                    "R": 0,
+                    "G": 0,
+                    "B": 0,
+                    "A": 0
+                  },
+                  "Shadow": null
+                },
+                {
+                  "Text": "11:57:00 PM",
+                  "Color": {
+                    "R": 0,
+                    "G": 0,
+                    "B": 0,
+                    "A": 0,
+                    "Semantic": "secondaryLabelColor"
+                  },
+                  "FontSize": 11,
+                  "FontWeight": 0,
+                  "Monospaced": true,
+                  "Badge": false,
+                  "Underline": false,
+                  "UnderlineColor": {
+                    "R": 0,
+                    "G": 0,
+                    "B": 0,
+                    "A": 0
+                  },
+                  "Strikethrough": false,
+                  "StrikethroughColor": {
+                    "R": 0,
+                    "G": 0,
+                    "B": 0,
+                    "A": 0
+                  },
+                  "Background": {
+                    "R": 0,
+                    "G": 0,
+                    "B": 0,
+                    "A": 0
+                  },
+                  "Shadow": null
+                }
+              ],
+              "color": {
+                "R": 0,
+                "G": 0,
+                "B": 0,
+                "A": 0
+              }
+            },
+            {
+              "type": "separator",
+              "color": {
+                "R": 0,
+                "G": 0,
+                "B": 0,
+                "A": 0
+              }
+            },
+            {
+              "type": "regular",
+              "text": "Open full size",
+              "color": {
+                "R": 0,
+                "G": 0,
+                "B": 0,
+                "A": 0
+              }
+            }
+          ]
+        },
+        {
+          "type": "regular",
+          "text": "Clickable image",
+          "color": {
+            "R": 0,
+            "G": 0,
+            "B": 0,
+            "A": 0
+          },
+          "children": [
+            {
+              "type": "image",
+              "color": {
+                "R": 0,
+                "G": 0,
+                "B": 0,
+                "A": 0
+              },
+              "imageWidth": 320,
+              "imageHeight": 360,
+              "imageSource": "data"
+            },
+            {
+              "type": "regular",
+              "runs": [
+                {
+                  "Text": "Clicked 0 time(s) — click the chart",
+                  "Color": {
+                    "R": 0,
+                    "G": 0,
+                    "B": 0,
+                    "A": 0,
+                    "Semantic": "secondaryLabelColor"
+                  },
+                  "FontSize": 11,
+                  "FontWeight": 0,
+                  "Monospaced": false,
+                  "Badge": false,
+                  "Underline": false,
+                  "UnderlineColor": {
+                    "R": 0,
+                    "G": 0,
+                    "B": 0,
+                    "A": 0
+                  },
+                  "Strikethrough": false,
+                  "StrikethroughColor": {
+                    "R": 0,
+                    "G": 0,
+                    "B": 0,
+                    "A": 0
+                  },
+                  "Background": {
+                    "R": 0,
+                    "G": 0,
+                    "B": 0,
+                    "A": 0
+                  },
+                  "Shadow": null
+                }
+              ],
+              "color": {
+                "R": 0,
+                "G": 0,
+                "B": 0,
+                "A": 0
+              }
+            }
+          ]
+        },
+        {
+          "type": "regular",
+          "text": "From a file path",
+          "color": {
+            "R": 0,
+            "G": 0,
+            "B": 0,
+            "A": 0
+          },
+          "children": [
+            {
+              "type": "image",
+              "color": {
+                "R": 0,
+                "G": 0,
+                "B": 0,
+                "A": 0
+              },
+              "imageWidth": 480,
+              "imageHeight": 360,
+              "imageSource": "path"
+            },
+            {
+              "type": "regular",
+              "runs": [
+                {
+                  "Text": "/var/folders/py/kd0n010d5853c10brzndjz8w0000gn/T/menuet-catalog-screenshot.png",
+                  "Color": {
+                    "R": 0,
+                    "G": 0,
+                    "B": 0,
+                    "A": 0,
+                    "Semantic": "tertiaryLabelColor"
+                  },
+                  "FontSize": 10,
+                  "FontWeight": 0,
+                  "Monospaced": true,
+                  "Badge": false,
+                  "Underline": false,
+                  "UnderlineColor": {
+                    "R": 0,
+                    "G": 0,
+                    "B": 0,
+                    "A": 0
+                  },
+                  "Strikethrough": false,
+                  "StrikethroughColor": {
+                    "R": 0,
+                    "G": 0,
+                    "B": 0,
+                    "A": 0
+                  },
+                  "Background": {
+                    "R": 0,
+                    "G": 0,
+                    "B": 0,
+                    "A": 0
+                  },
+                  "Shadow": null
+                }
+              ],
+              "color": {
+                "R": 0,
+                "G": 0,
+                "B": 0,
+                "A": 0
+              }
+            }
+          ]
+        },
+        {
+          "type": "regular",
+          "text": "Scale to fit (one 1440×900 source)",
+          "color": {
+            "R": 0,
+            "G": 0,
+            "B": 0,
+            "A": 0
+          },
+          "children": [
+            {
+              "type": "regular",
+              "runs": [
+                {
+                  "Text": "MaxWidth: 160",
+                  "Color": {
+                    "R": 0,
+                    "G": 0,
+                    "B": 0,
+                    "A": 0,
+                    "Semantic": "secondaryLabelColor"
+                  },
+                  "FontSize": 11,
+                  "FontWeight": 0,
+                  "Monospaced": true,
+                  "Badge": false,
+                  "Underline": false,
+                  "UnderlineColor": {
+                    "R": 0,
+                    "G": 0,
+                    "B": 0,
+                    "A": 0
+                  },
+                  "Strikethrough": false,
+                  "StrikethroughColor": {
+                    "R": 0,
+                    "G": 0,
+                    "B": 0,
+                    "A": 0
+                  },
+                  "Background": {
+                    "R": 0,
+                    "G": 0,
+                    "B": 0,
+                    "A": 0
+                  },
+                  "Shadow": null
+                }
+              ],
+              "color": {
+                "R": 0,
+                "G": 0,
+                "B": 0,
+                "A": 0
+              }
+            },
+            {
+              "type": "image",
+              "color": {
+                "R": 0,
+                "G": 0,
+                "B": 0,
+                "A": 0
+              },
+              "imageWidth": 160,
+              "imageHeight": 360,
+              "imageSource": "data"
+            },
+            {
+              "type": "regular",
+              "runs": [
+                {
+                  "Text": "MaxWidth: 300",
+                  "Color": {
+                    "R": 0,
+                    "G": 0,
+                    "B": 0,
+                    "A": 0,
+                    "Semantic": "secondaryLabelColor"
+                  },
+                  "FontSize": 11,
+                  "FontWeight": 0,
+                  "Monospaced": true,
+                  "Badge": false,
+                  "Underline": false,
+                  "UnderlineColor": {
+                    "R": 0,
+                    "G": 0,
+                    "B": 0,
+                    "A": 0
+                  },
+                  "Strikethrough": false,
+                  "StrikethroughColor": {
+                    "R": 0,
+                    "G": 0,
+                    "B": 0,
+                    "A": 0
+                  },
+                  "Background": {
+                    "R": 0,
+                    "G": 0,
+                    "B": 0,
+                    "A": 0
+                  },
+                  "Shadow": null
+                }
+              ],
+              "color": {
+                "R": 0,
+                "G": 0,
+                "B": 0,
+                "A": 0
+              }
+            },
+            {
+              "type": "image",
+              "color": {
+                "R": 0,
+                "G": 0,
+                "B": 0,
+                "A": 0
+              },
+              "imageWidth": 300,
+              "imageHeight": 360,
+              "imageSource": "data"
+            },
+            {
+              "type": "regular",
+              "runs": [
+                {
+                  "Text": "default bound (480×360)",
+                  "Color": {
+                    "R": 0,
+                    "G": 0,
+                    "B": 0,
+                    "A": 0,
+                    "Semantic": "secondaryLabelColor"
+                  },
+                  "FontSize": 11,
+                  "FontWeight": 0,
+                  "Monospaced": true,
+                  "Badge": false,
+                  "Underline": false,
+                  "UnderlineColor": {
+                    "R": 0,
+                    "G": 0,
+                    "B": 0,
+                    "A": 0
+                  },
+                  "Strikethrough": false,
+                  "StrikethroughColor": {
+                    "R": 0,
+                    "G": 0,
+                    "B": 0,
+                    "A": 0
+                  },
+                  "Background": {
+                    "R": 0,
+                    "G": 0,
+                    "B": 0,
+                    "A": 0
+                  },
+                  "Shadow": null
+                }
+              ],
+              "color": {
+                "R": 0,
+                "G": 0,
+                "B": 0,
+                "A": 0
+              }
+            },
+            {
+              "type": "image",
+              "color": {
+                "R": 0,
+                "G": 0,
+                "B": 0,
+                "A": 0
+              },
+              "imageWidth": 480,
+              "imageHeight": 360,
+              "imageSource": "data"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/html/render.go
+++ b/html/render.go
@@ -221,9 +221,38 @@ func renderItem(b *strings.Builder, item menuet.SnapshotItem, opts Options, dept
 		}
 		b.WriteString(`</div>`)
 		b.WriteString(`</div>`)
+	case "image":
+		renderImagePlaceholder(b, item)
 	default:
 		renderRegular(b, item, opts, depth)
 	}
+}
+
+// renderImagePlaceholder stands in for a menuet.Image row. Snapshots
+// deliberately don't carry the picture's bytes (see SnapshotItem), so the mock
+// draws a box at the item's declared bound, scaled to fit the panel.
+func renderImagePlaceholder(b *strings.Builder, item menuet.SnapshotItem) {
+	w, h := item.ImageWidth, item.ImageHeight
+	if w <= 0 {
+		w = 480
+	}
+	if h <= 0 {
+		h = 360
+	}
+	// The mock menu panel is 320px wide; keep the placeholder inside it,
+	// preserving the declared aspect ratio.
+	const panelW = 292
+	if w > panelW {
+		h = h * panelW / w
+		w = panelW
+	}
+	fmt.Fprintf(b,
+		`<div style="margin: 3px 5px; padding: 0 7px;">`+
+			`<div style="width: %dpx; height: %dpx; border-radius: 6px; border: 1px solid var(--sep); `+
+			`background: repeating-linear-gradient(135deg, var(--field-bg), var(--field-bg) 8px, transparent 8px, transparent 16px); `+
+			`display: flex; align-items: center; justify-content: center; `+
+			`color: var(--text-3); font-size: 11px;">image · %d×%d</div></div>`,
+		w, h, item.ImageWidth, item.ImageHeight)
 }
 
 // renderHoverSubmenu emits a hidden-by-default submenu popover inside

--- a/image_test.go
+++ b/image_test.go
@@ -55,35 +55,20 @@ func TestImageClickableOnlyWhenClickedSet(t *testing.T) {
 	}
 }
 
-// Zero MaxWidth/MaxHeight are forwarded as zero; the ObjC side substitutes the
-// documented defaults. Assert the constants stay in step with menuet.m, which
-// is where the substitution actually happens.
-func TestImageDefaultBoundsAreForwardedAsZero(t *testing.T) {
+// Default bounds are substituted once here in Go — every consumer (ObjC
+// bridge, snapshots) sees concrete values, so the defaults live in exactly
+// one place. Per-axis: an explicit value on one axis keeps the default on
+// the other.
+func TestImageDefaultBoundsSubstituted(t *testing.T) {
 	item := buildInternalItem(Image{Data: []byte{1}}, "u1", "p1")
-	if item.MaxWidth != 0 || item.MaxHeight != 0 {
-		t.Errorf("zero bounds should pass through as zero, got %dx%d",
+	if item.MaxWidth != DefaultMaxImageWidth || item.MaxHeight != DefaultMaxImageHeight {
+		t.Errorf("zero bounds should become defaults, got %dx%d",
 			item.MaxWidth, item.MaxHeight)
 	}
-	if DefaultMaxImageWidth != 480 || DefaultMaxImageHeight != 360 {
-		t.Errorf("defaults changed (%dx%d) — update the matching literals in menuet.m",
-			DefaultMaxImageWidth, DefaultMaxImageHeight)
-	}
-}
-
-// An Image is a MenuItem, so it composes: as the only child of a Regular it is
-// "a submenu that is an image", and it can sit alongside ordinary rows.
-func TestImageIsAMenuItem(t *testing.T) {
-	var items []MenuItem
-	items = append(items,
-		Image{Data: []byte{1}},
-		Separator{},
-		Regular{Text: "Open full size"},
-	)
-	if len(items) != 3 {
-		t.Fatalf("want 3 items, got %d", len(items))
-	}
-	if _, ok := items[0].(Image); !ok {
-		t.Errorf("first item is not an Image: %T", items[0])
+	item = buildInternalItem(Image{Data: []byte{1}, MaxWidth: 200}, "u2", "p1")
+	if item.MaxWidth != 200 || item.MaxHeight != DefaultMaxImageHeight {
+		t.Errorf("explicit width should keep default height, got %dx%d",
+			item.MaxWidth, item.MaxHeight)
 	}
 }
 

--- a/image_test.go
+++ b/image_test.go
@@ -1,0 +1,102 @@
+package menuet
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestImageWithDataSerializes(t *testing.T) {
+	// Not a real PNG — buildInternalItem doesn't decode, it just forwards.
+	raw := []byte{0x89, 'P', 'N', 'G', 0x0d, 0x0a}
+	item := buildInternalItem(Image{Data: raw, MaxWidth: 480, MaxHeight: 360}, "u1", "p1")
+
+	if item.Type != "image" {
+		t.Fatalf("Type = %q, want image", item.Type)
+	}
+	b, err := json.Marshal(item)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// encoding/json base64s a []byte; the ObjC side decodes it back.
+	want := base64.StdEncoding.EncodeToString(raw)
+	if !strings.Contains(string(b), want) {
+		t.Errorf("ImageData not base64-encoded into JSON: %s", b)
+	}
+	if !strings.Contains(string(b), `"MaxWidth":480`) ||
+		!strings.Contains(string(b), `"MaxHeight":360`) {
+		t.Errorf("max bounds missing: %s", b)
+	}
+}
+
+func TestImageWithPathSerializes(t *testing.T) {
+	item := buildInternalItem(Image{Path: "/tmp/shot.png"}, "u1", "p1")
+	if item.ImagePath != "/tmp/shot.png" {
+		t.Errorf("ImagePath = %q", item.ImagePath)
+	}
+	b, _ := json.Marshal(item)
+	// A path-sourced image must not smuggle an empty ImageData key across the
+	// bridge — omitempty keeps the payload lean.
+	if strings.Contains(string(b), `"ImageData"`) {
+		t.Errorf("empty ImageData should be omitted: %s", b)
+	}
+}
+
+func TestImageClickableOnlyWhenClickedSet(t *testing.T) {
+	still := buildInternalItem(Image{Data: []byte{1}}, "u1", "p1")
+	if still.Clickable {
+		t.Error("a decorative Image must not be Clickable")
+	}
+	live := buildInternalItem(Image{Data: []byte{1}, Clicked: func() {}}, "u2", "p1")
+	if !live.Clickable {
+		t.Error("an Image with Clicked must be Clickable")
+	}
+}
+
+// Zero MaxWidth/MaxHeight are forwarded as zero; the ObjC side substitutes the
+// documented defaults. Assert the constants stay in step with menuet.m, which
+// is where the substitution actually happens.
+func TestImageDefaultBoundsAreForwardedAsZero(t *testing.T) {
+	item := buildInternalItem(Image{Data: []byte{1}}, "u1", "p1")
+	if item.MaxWidth != 0 || item.MaxHeight != 0 {
+		t.Errorf("zero bounds should pass through as zero, got %dx%d",
+			item.MaxWidth, item.MaxHeight)
+	}
+	if DefaultMaxImageWidth != 480 || DefaultMaxImageHeight != 360 {
+		t.Errorf("defaults changed (%dx%d) — update the matching literals in menuet.m",
+			DefaultMaxImageWidth, DefaultMaxImageHeight)
+	}
+}
+
+// An Image is a MenuItem, so it composes: as the only child of a Regular it is
+// "a submenu that is an image", and it can sit alongside ordinary rows.
+func TestImageIsAMenuItem(t *testing.T) {
+	var items []MenuItem
+	items = append(items,
+		Image{Data: []byte{1}},
+		Separator{},
+		Regular{Text: "Open full size"},
+	)
+	if len(items) != 3 {
+		t.Fatalf("want 3 items, got %d", len(items))
+	}
+	if _, ok := items[0].(Image); !ok {
+		t.Errorf("first item is not an Image: %T", items[0])
+	}
+}
+
+func TestImageClickRoutesToCallback(t *testing.T) {
+	fired := make(chan struct{}, 1)
+	a := &Application{visibleMenuItems: make(map[string]internalItem)}
+	img := Image{Data: []byte{1}, Clicked: func() { fired <- struct{}{} }}
+	a.visibleMenuItems["u1"] = buildInternalItem(img, "u1", "root")
+
+	a.clicked("u1")
+	select {
+	case <-fired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("clicking an Image did not invoke its Clicked callback")
+	}
+}

--- a/menuet.go
+++ b/menuet.go
@@ -178,8 +178,15 @@ func (a *Application) clicked(unique string) {
 		log.Printf("Item not found for click: %s", unique)
 		return
 	}
-	if reg, ok := item.item.(Regular); ok && reg.Clicked != nil {
-		go reg.Clicked()
+	switch v := item.item.(type) {
+	case Regular:
+		if v.Clicked != nil {
+			go v.Clicked()
+		}
+	case Image:
+		if v.Clicked != nil {
+			go v.Clicked()
+		}
 	}
 }
 

--- a/menuet.m
+++ b/menuet.m
@@ -361,11 +361,18 @@ static NSImage *MenuetScaledImage(NSImage *src, CGFloat maxW, CGFloat maxH) {
 	return out;
 }
 
-static NSImage *MenuetImageForRow(NSData *data, NSString *path, CGFloat maxW, CGFloat maxH) {
+// MenuetImageForRow returns the decoded, scaled image for a row, cached.
+// b64 is the still-encoded ImageData payload: hashing it directly (rather
+// than the decoded bytes) has identical uniqueness but defers the ~1MB
+// base64 decode to the cache-miss path, keeping repeat menu opens cheap.
+// Failures are cached too (as NSNull), so a broken source is decoded — and
+// logged — once, not on every open.
+static NSImage *MenuetImageForRow(NSString *b64, NSString *path, CGFloat maxW, CGFloat maxH) {
 	NSString *key = nil;
-	if (data.length > 0) {
+	if (b64.length > 0) {
+		NSData *keyBytes = [b64 dataUsingEncoding:NSUTF8StringEncoding];
 		key = [NSString stringWithFormat:@"d:%@/%.0fx%.0f",
-		       MenuetSHA256Hex(data), maxW, maxH];
+		       MenuetSHA256Hex(keyBytes), maxW, maxH];
 	} else if (path.length > 0) {
 		NSDictionary *attrs =
 			[[NSFileManager defaultManager] attributesOfItemAtPath:path error:nil];
@@ -376,22 +383,27 @@ static NSImage *MenuetImageForRow(NSData *data, NSString *path, CGFloat maxW, CG
 		return nil;
 	}
 
-	NSImage *cached = [MenuetImageCache() objectForKey:key];
+	id cached = [MenuetImageCache() objectForKey:key];
 	if (cached) {
-		return cached;
+		return cached == [NSNull null] ? nil : cached;
 	}
 
-	NSImage *src = data.length > 0
+	NSImage *scaled = nil;
+	NSData *data = b64.length > 0
+		? [[NSData alloc] initWithBase64EncodedString:b64 options:0]
+		: nil;
+	NSImage *src = data
 		? [[NSImage alloc] initWithData:data]
 		: [[NSImage alloc] initWithContentsOfFile:path];
-	if (!src) {
-		NSLog(@"menuet: could not decode image (%@)",
-		      data.length > 0 ? @"Data" : path);
-		return nil;
+	if (src) {
+		scaled = MenuetScaledImage(src, maxW, maxH);
 	}
-	NSImage *scaled = MenuetScaledImage(src, maxW, maxH);
 	if (scaled) {
 		[MenuetImageCache() setObject:scaled forKey:key];
+	} else {
+		NSLog(@"menuet: could not decode image (%@)",
+		      b64.length > 0 ? @"Data" : path);
+		[MenuetImageCache() setObject:[NSNull null] forKey:key];
 	}
 	return scaled;
 }
@@ -413,13 +425,9 @@ static NSImage *MenuetImageForRow(NSData *data, NSString *path, CGFloat maxW, CG
 @implementation MenuetImageView
 
 - (instancetype)initWithImage:(NSImage *)image clickable:(BOOL)clickable {
-	NSSize size = image ? image.size : NSMakeSize(120, 60);
-	self = [super initWithFrame:NSMakeRect(0, 0,
-	                                       size.width + 2 * kMenuetImagePadX,
-	                                       size.height + 2 * kMenuetImagePadY)];
+	self = [super initWithFrame:NSZeroRect];
 	if (self) {
-		_image = image;
-		_clickable = clickable;
+		[self updateImage:image clickable:clickable];
 	}
 	return self;
 }
@@ -427,6 +435,10 @@ static NSImage *MenuetImageForRow(NSData *data, NSString *path, CGFloat maxW, CG
 - (void)updateImage:(NSImage *)image clickable:(BOOL)clickable {
 	self.image = image;
 	self.clickable = clickable;
+	// The menu can be dismissed (cancelTracking) with the pointer still over
+	// this row, in which case mouseExited never arrives — reset here so a
+	// reused view doesn't draw a phantom highlight on the next open.
+	self.hovered = NO;
 	NSSize size = image ? image.size : NSMakeSize(120, 60);
 	NSRect frame = self.frame;
 	frame.size = NSMakeSize(size.width + 2 * kMenuetImagePadX,
@@ -440,10 +452,14 @@ static NSImage *MenuetImageForRow(NSData *data, NSString *path, CGFloat maxW, CG
 	if (self.tracking) {
 		[self removeTrackingArea:self.tracking];
 	}
+	// ActiveAlways, not ActiveInActiveApp: menuet apps are accessory-policy
+	// apps whose status-item menu opens without activating the app, so
+	// ActiveInActiveApp would never deliver enter/exit while another app is
+	// frontmost — i.e. in the normal menubar usage.
 	self.tracking = [[NSTrackingArea alloc]
 	                 initWithRect:self.bounds
 	                      options:NSTrackingMouseEnteredAndExited |
-	                              NSTrackingActiveInActiveApp
+	                              NSTrackingActiveAlways
 	                        owner:self
 	                     userInfo:nil];
 	[self addTrackingArea:self.tracking];
@@ -652,20 +668,17 @@ static NSString *MenuetPlainTextFromRuns(NSArray *runs) {
 			continue;
 		}
 		if ([type isEqualTo:@"image"]) {
-			// encoding/json base64s a Go []byte, so ImageData arrives as a string.
-			NSString *b64 = dict[@"ImageData"];
-			NSData *imageData = [b64 isKindOfClass:[NSString class]] && b64.length > 0
-				? [[NSData alloc] initWithBase64EncodedString:b64 options:0]
-				: nil;
+			// encoding/json base64s a Go []byte, so ImageData arrives as a
+			// string; MenuetImageForRow decodes it only on a cache miss.
+			// MaxWidth/MaxHeight arrive with defaults already substituted by
+			// buildInternalItem — Go owns the boundary, this side trusts it.
+			NSString *b64 = [dict[@"ImageData"] isKindOfClass:[NSString class]]
+				? dict[@"ImageData"] : @"";
 			NSString *imagePath = dict[@"ImagePath"] ?: @"";
 			CGFloat maxW = [dict[@"MaxWidth"] doubleValue];
 			CGFloat maxH = [dict[@"MaxHeight"] doubleValue];
-			// Zero means "use the default bound for that axis" — an unscaled
-			// screenshot would otherwise run off the screen.
-			if (maxW <= 0) maxW = 480;
-			if (maxH <= 0) maxH = 360;
 
-			NSImage *picture = MenuetImageForRow(imageData, imagePath, maxW, maxH);
+			NSImage *picture = MenuetImageForRow(b64, imagePath, maxW, maxH);
 			BOOL imageClickable = [dict[@"Clickable"] boolValue];
 			NSString *imageUnique = dict[@"Unique"];
 
@@ -722,7 +735,14 @@ static NSString *MenuetPlainTextFromRuns(NSArray *runs) {
 		BOOL state = [dict[@"State"] boolValue];
 		BOOL hasChildren = [dict[@"HasChildren"] boolValue];
 		BOOL clickable = [dict[@"Clickable"] boolValue];
-		if (!item || item.isSeparatorItem) {
+		// A leftover custom view (image or search row that changed type at
+		// this index) would supersede the title we set below —
+		// NSMenuItem.view wins over attributedTitle — so those items can't
+		// be reused for a regular row.
+		if (!item || item.isSeparatorItem || item.view) {
+			if (item) {
+				[self removeItemAtIndex:i];
+			}
 			item =
 				[self insertItemWithTitle:@"" action:nil keyEquivalent:@"" atIndex:i];
 		}

--- a/menuet.m
+++ b/menuet.m
@@ -2,6 +2,7 @@
 #import <UserNotifications/UserNotifications.h>
 #import <Carbon/Carbon.h>
 #import <ServiceManagement/ServiceManagement.h>
+#import <CommonCrypto/CommonDigest.h>
 
 #import "NSImage+Resize.h"
 #import "menuet.h"
@@ -294,6 +295,204 @@ static NSColor *MenuetColorFromDict(NSDictionary *dict) {
 // rectangle filled with fillColor, with the text drawn in white-on-fill
 // at 9pt bold uppercase. The image's size matches the badge geometry
 // from the design handoff (h14, padX5, radius7).
+// ---------------------------------------------------------------------------
+// Image menu rows (the "image" item type).
+//
+// Decoding and rescaling a full-size screenshot on every menu open is the
+// expensive part, so results are cached. The cache key must change when the
+// picture does: for Data that's a digest of the bytes, for Path it's the
+// path plus its modification time (a screenshot rewritten to the same path
+// must not serve the stale image).
+// ---------------------------------------------------------------------------
+
+static const CGFloat kMenuetImagePadX = 20; // roughly the menu's text inset
+static const CGFloat kMenuetImagePadY = 5;
+
+static NSCache *MenuetImageCache(void) {
+	static NSCache *cache;
+	static dispatch_once_t once;
+	dispatch_once(&once, ^{
+		cache = [[NSCache alloc] init];
+		cache.countLimit = 32;
+	});
+	return cache;
+}
+
+static NSString *MenuetSHA256Hex(NSData *data) {
+	unsigned char digest[CC_SHA256_DIGEST_LENGTH];
+	CC_SHA256(data.bytes, (CC_LONG)data.length, digest);
+	NSMutableString *hex = [NSMutableString stringWithCapacity:CC_SHA256_DIGEST_LENGTH * 2];
+	for (int i = 0; i < CC_SHA256_DIGEST_LENGTH; i++) {
+		[hex appendFormat:@"%02x", digest[i]];
+	}
+	return hex;
+}
+
+// Scale to fit inside maxW x maxH, preserving aspect ratio. Never upscales —
+// a 32pt avatar in a 480pt box stays 32pt rather than turning to mush.
+static NSImage *MenuetScaledImage(NSImage *src, CGFloat maxW, CGFloat maxH) {
+	if (!src || !src.isValid) {
+		return nil;
+	}
+	NSSize size = src.size;
+	if (size.width <= 0 || size.height <= 0) {
+		return nil;
+	}
+	CGFloat scale = 1.0;
+	if (maxW > 0 && size.width > maxW) {
+		scale = MIN(scale, maxW / size.width);
+	}
+	if (maxH > 0 && size.height > maxH) {
+		scale = MIN(scale, maxH / size.height);
+	}
+	if (scale >= 1.0) {
+		return src;
+	}
+	NSSize newSize = NSMakeSize(floor(size.width * scale), floor(size.height * scale));
+	NSImage *out = [[NSImage alloc] initWithSize:newSize];
+	[out lockFocus];
+	[[NSGraphicsContext currentContext]
+	 setImageInterpolation:NSImageInterpolationHigh];
+	[src drawInRect:NSMakeRect(0, 0, newSize.width, newSize.height)
+	       fromRect:NSZeroRect
+	      operation:NSCompositingOperationSourceOver
+	       fraction:1.0];
+	[out unlockFocus];
+	return out;
+}
+
+static NSImage *MenuetImageForRow(NSData *data, NSString *path, CGFloat maxW, CGFloat maxH) {
+	NSString *key = nil;
+	if (data.length > 0) {
+		key = [NSString stringWithFormat:@"d:%@/%.0fx%.0f",
+		       MenuetSHA256Hex(data), maxW, maxH];
+	} else if (path.length > 0) {
+		NSDictionary *attrs =
+			[[NSFileManager defaultManager] attributesOfItemAtPath:path error:nil];
+		NSDate *mtime = attrs[NSFileModificationDate];
+		key = [NSString stringWithFormat:@"p:%@/%f/%.0fx%.0f", path,
+		       mtime.timeIntervalSince1970, maxW, maxH];
+	} else {
+		return nil;
+	}
+
+	NSImage *cached = [MenuetImageCache() objectForKey:key];
+	if (cached) {
+		return cached;
+	}
+
+	NSImage *src = data.length > 0
+		? [[NSImage alloc] initWithData:data]
+		: [[NSImage alloc] initWithContentsOfFile:path];
+	if (!src) {
+		NSLog(@"menuet: could not decode image (%@)",
+		      data.length > 0 ? @"Data" : path);
+		return nil;
+	}
+	NSImage *scaled = MenuetScaledImage(src, maxW, maxH);
+	if (scaled) {
+		[MenuetImageCache() setObject:scaled forKey:key];
+	}
+	return scaled;
+}
+
+// MenuetImageView is an NSMenuItem.view that draws a picture as the row. Same
+// mechanism as the search field. A custom view gets none of NSMenuItem's
+// highlight or click behavior for free, so when the row is clickable we track
+// the pointer ourselves, draw the selection background, and on mouseUp fire
+// the item's action and dismiss the menu.
+@interface MenuetImageView : NSView
+@property(nonatomic, strong) NSImage *image;
+@property(nonatomic, assign) BOOL clickable;
+@property(nonatomic, assign) BOOL hovered;
+@property(nonatomic, strong) NSTrackingArea *tracking;
+- (instancetype)initWithImage:(NSImage *)image clickable:(BOOL)clickable;
+- (void)updateImage:(NSImage *)image clickable:(BOOL)clickable;
+@end
+
+@implementation MenuetImageView
+
+- (instancetype)initWithImage:(NSImage *)image clickable:(BOOL)clickable {
+	NSSize size = image ? image.size : NSMakeSize(120, 60);
+	self = [super initWithFrame:NSMakeRect(0, 0,
+	                                       size.width + 2 * kMenuetImagePadX,
+	                                       size.height + 2 * kMenuetImagePadY)];
+	if (self) {
+		_image = image;
+		_clickable = clickable;
+	}
+	return self;
+}
+
+- (void)updateImage:(NSImage *)image clickable:(BOOL)clickable {
+	self.image = image;
+	self.clickable = clickable;
+	NSSize size = image ? image.size : NSMakeSize(120, 60);
+	NSRect frame = self.frame;
+	frame.size = NSMakeSize(size.width + 2 * kMenuetImagePadX,
+	                        size.height + 2 * kMenuetImagePadY);
+	self.frame = frame;
+	[self setNeedsDisplay:YES];
+}
+
+- (void)updateTrackingAreas {
+	[super updateTrackingAreas];
+	if (self.tracking) {
+		[self removeTrackingArea:self.tracking];
+	}
+	self.tracking = [[NSTrackingArea alloc]
+	                 initWithRect:self.bounds
+	                      options:NSTrackingMouseEnteredAndExited |
+	                              NSTrackingActiveInActiveApp
+	                        owner:self
+	                     userInfo:nil];
+	[self addTrackingArea:self.tracking];
+}
+
+- (void)mouseEntered:(NSEvent *)event {
+	if (self.clickable && !self.hovered) {
+		self.hovered = YES;
+		[self setNeedsDisplay:YES];
+	}
+}
+
+- (void)mouseExited:(NSEvent *)event {
+	if (self.hovered) {
+		self.hovered = NO;
+		[self setNeedsDisplay:YES];
+	}
+}
+
+- (void)mouseUp:(NSEvent *)event {
+	if (!self.clickable) {
+		return;
+	}
+	NSMenuItem *item = self.enclosingMenuItem;
+	if (item.action) {
+		[NSApp sendAction:item.action to:item.target from:item];
+	}
+	[item.menu cancelTracking];
+}
+
+- (void)drawRect:(NSRect)dirtyRect {
+	if (self.clickable && self.hovered) {
+		[[NSColor selectedContentBackgroundColor] setFill];
+		NSRect r = NSInsetRect(self.bounds, 5, 1);
+		[[NSBezierPath bezierPathWithRoundedRect:r xRadius:5 yRadius:5] fill];
+	}
+	if (!self.image) {
+		return;
+	}
+	[self.image drawInRect:NSMakeRect(kMenuetImagePadX, kMenuetImagePadY,
+	                                  self.image.size.width,
+	                                  self.image.size.height)
+	              fromRect:NSZeroRect
+	             operation:NSCompositingOperationSourceOver
+	              fraction:1.0];
+}
+
+@end
+
 static NSImage *MenuetBadgeImage(NSString *text, NSColor *fillColor) {
 	NSString *upper = [text uppercaseString];
 	NSDictionary *attrs = @{
@@ -450,6 +649,45 @@ static NSString *MenuetPlainTextFromRuns(NSArray *runs) {
 			if (!item || !item.isSeparatorItem) {
 				[self insertItem:[NSMenuItem separatorItem] atIndex:i];
 			}
+			continue;
+		}
+		if ([type isEqualTo:@"image"]) {
+			// encoding/json base64s a Go []byte, so ImageData arrives as a string.
+			NSString *b64 = dict[@"ImageData"];
+			NSData *imageData = [b64 isKindOfClass:[NSString class]] && b64.length > 0
+				? [[NSData alloc] initWithBase64EncodedString:b64 options:0]
+				: nil;
+			NSString *imagePath = dict[@"ImagePath"] ?: @"";
+			CGFloat maxW = [dict[@"MaxWidth"] doubleValue];
+			CGFloat maxH = [dict[@"MaxHeight"] doubleValue];
+			// Zero means "use the default bound for that axis" — an unscaled
+			// screenshot would otherwise run off the screen.
+			if (maxW <= 0) maxW = 480;
+			if (maxH <= 0) maxH = 360;
+
+			NSImage *picture = MenuetImageForRow(imageData, imagePath, maxW, maxH);
+			BOOL imageClickable = [dict[@"Clickable"] boolValue];
+			NSString *imageUnique = dict[@"Unique"];
+
+			BOOL reuseImage = item && [item.view isKindOfClass:NSClassFromString(@"MenuetImageView")];
+			if (!reuseImage) {
+				if (item) [self removeItemAtIndex:i];
+				item = [self insertItemWithTitle:@"" action:nil keyEquivalent:@"" atIndex:i];
+				item.view = [[MenuetImageView alloc] initWithImage:picture
+				                                         clickable:imageClickable];
+			} else {
+				[(MenuetImageView *)item.view updateImage:picture
+				                                clickable:imageClickable];
+			}
+			item.target = self;
+			if (imageClickable) {
+				item.action = @selector(press:);
+				item.representedObject = imageUnique;
+			} else {
+				item.action = nil;
+				item.representedObject = nil;
+			}
+			item.enabled = imageClickable;
 			continue;
 		}
 		if ([type isEqualTo:@"search"]) {

--- a/menuitem.go
+++ b/menuitem.go
@@ -208,8 +208,17 @@ func buildInternalItem(item MenuItem, unique, parentUnique string) internalItem 
 		}
 		out.ImageData = v.Data
 		out.ImagePath = v.Path
+		// Substitute the default bounds here, once, so every consumer (the
+		// ObjC bridge, snapshots) sees concrete values — no cross-language
+		// duplication of the defaults.
 		out.MaxWidth = v.MaxWidth
+		if out.MaxWidth <= 0 {
+			out.MaxWidth = DefaultMaxImageWidth
+		}
 		out.MaxHeight = v.MaxHeight
+		if out.MaxHeight <= 0 {
+			out.MaxHeight = DefaultMaxImageHeight
+		}
 		out.Clickable = v.Clicked != nil
 	}
 	return out

--- a/menuitem.go
+++ b/menuitem.go
@@ -78,6 +78,62 @@ type Search struct {
 
 func (Search) menuItem() {}
 
+// DefaultMaxImageWidth and DefaultMaxImageHeight bound an Image whose
+// MaxWidth / MaxHeight are left at zero, so an unscaled screenshot can't
+// push the menu off the screen.
+const (
+	DefaultMaxImageWidth  = 480
+	DefaultMaxImageHeight = 360
+)
+
+// Image is a menu row that renders a picture in place of text. As the only
+// child of a Regular it makes a submenu that *is* an image; alongside other
+// items it's a picture above a caption, a "Open full size" row, and so on:
+//
+//	menuet.Regular{
+//	    Text: "Living room iMac",
+//	    Children: func() []menuet.MenuItem {
+//	        return []menuet.MenuItem{
+//	            menuet.Image{Data: screenshotPNG, MaxWidth: 480},
+//	            menuet.Separator{},
+//	            menuet.Regular{Text: "Open full size", Clicked: openFull},
+//	        }
+//	    },
+//	}
+//
+// This is a different thing from Regular.Image, which is a small (16pt-tall)
+// icon drawn to the *left* of a row's text. Image is the row.
+//
+// Exactly one of Data or Path must be set. menuet never fetches an image
+// itself: there is deliberately no URL field, because the fetch would land on
+// the thread building the menu (hanging it) and could not carry an
+// Authorization header. Fetch it in Go — where you already have your auth,
+// caching and retries — and hand over the bytes or a path.
+type Image struct {
+	// Data is the encoded image (PNG, JPEG, …). Use it when your Go code
+	// already holds the bytes: a screenshot pulled from an authenticated API,
+	// a chart you rendered in-process. The bytes cross the cgo bridge on every
+	// menu open, so prefer Path for large, unchanging images.
+	Data []byte
+
+	// Path is an absolute path to an image file. Cheaper than Data for large
+	// images — only the path crosses the bridge — and cached by path, size and
+	// modification time, so rewriting the file shows the new picture.
+	Path string
+
+	// MaxWidth and MaxHeight bound the rendered picture. It is scaled down to
+	// fit inside them, preserving aspect ratio, and is never scaled up. A zero
+	// value means DefaultMaxImageWidth / DefaultMaxImageHeight for that axis.
+	MaxWidth  int
+	MaxHeight int
+
+	// Clicked, when set, makes the row respond to clicks and highlight under
+	// the pointer, like a Regular. Leave nil for a purely decorative picture.
+	Clicked func()
+}
+
+func (Image) menuItem() {}
+
 type internalItem struct {
 	Unique       string
 	ParentUnique string
@@ -98,6 +154,13 @@ type internalItem struct {
 	State       bool
 	HasChildren bool
 	Clickable   bool
+
+	// Image ("image" Type) fields. ImageData is []byte, which encoding/json
+	// base64-encodes for us; the ObjC side decodes it back.
+	ImageData []byte `json:",omitempty"`
+	ImagePath string `json:",omitempty"`
+	MaxWidth  int    `json:",omitempty"`
+	MaxHeight int    `json:",omitempty"`
 
 	// item is the original MenuItem, kept so click and Children callbacks
 	// can be looked up later when ObjC re-enters via itemClicked / children.
@@ -131,6 +194,23 @@ func buildInternalItem(item MenuItem, unique, parentUnique string) internalItem 
 		out.Type = "search"
 		// Text doubles as the placeholder string on the ObjC side.
 		out.Text = v.Placeholder
+	case Image:
+		out.Type = "image"
+		// Exactly one source. Neither means nothing to draw; both is
+		// ambiguous. Say so rather than silently picking one — the row would
+		// otherwise just render blank with no clue why.
+		hasData, hasPath := len(v.Data) > 0, v.Path != ""
+		switch {
+		case !hasData && !hasPath:
+			log.Printf("menuet: Image has neither Data nor Path; nothing to draw")
+		case hasData && hasPath:
+			log.Printf("menuet: Image has both Data and Path; set exactly one")
+		}
+		out.ImageData = v.Data
+		out.ImagePath = v.Path
+		out.MaxWidth = v.MaxWidth
+		out.MaxHeight = v.MaxHeight
+		out.Clickable = v.Clicked != nil
 	}
 	return out
 }

--- a/snapshot.go
+++ b/snapshot.go
@@ -39,8 +39,8 @@ type Snapshot struct {
 // Unique/ParentUnique and a live *MenuItem pointer) so the snapshot stays
 // a self-contained data payload with no live references.
 type SnapshotItem struct {
-	// Type is "regular", "separator", or "search". Empty means regular for
-	// backward-compatibility when the field is omitted.
+	// Type is "regular", "separator", "search", or "image". Empty means
+	// regular for backward-compatibility when the field is omitted.
 	Type string `json:"type,omitempty"`
 
 	Text       string     `json:"text,omitempty"`
@@ -53,6 +53,14 @@ type SnapshotItem struct {
 	Monospaced bool       `json:"monospaced,omitempty"`
 	Shortcut   *Shortcut  `json:"shortcut,omitempty"`
 	State      bool       `json:"state,omitempty"`
+
+	// Image ("image" Type) fields. The picture's bytes are deliberately NOT
+	// captured: a screenshot base64s to ~1MB, and a snapshot is a structural
+	// record of the menu, not an asset bundle. Renderers draw a placeholder at
+	// the item's declared bound. ImageSource is "data" or "path".
+	ImageWidth  int    `json:"imageWidth,omitempty"`
+	ImageHeight int    `json:"imageHeight,omitempty"`
+	ImageSource string `json:"imageSource,omitempty"`
 
 	// Children are the expanded submenu, populated by the snapshotter.
 	Children []SnapshotItem `json:"children,omitempty"`
@@ -150,6 +158,26 @@ func snapshotItem(item MenuItem, depth int) SnapshotItem {
 		return s
 	case Separator:
 		return SnapshotItem{Type: "separator"}
+	case Image:
+		// Record the effective bound (applying the same defaults the ObjC side
+		// would) so a renderer knows how much room the picture takes.
+		w, h := v.MaxWidth, v.MaxHeight
+		if w <= 0 {
+			w = DefaultMaxImageWidth
+		}
+		if h <= 0 {
+			h = DefaultMaxImageHeight
+		}
+		source := "data"
+		if v.Path != "" {
+			source = "path"
+		}
+		return SnapshotItem{
+			Type:        "image",
+			ImageWidth:  w,
+			ImageHeight: h,
+			ImageSource: source,
+		}
 	case Search:
 		s := SnapshotItem{Type: "search", Text: v.Placeholder}
 		// Snapshot search results with an empty query — the same call the


### PR DESCRIPTION
A new `MenuItem` type, `menuet.Image`. As the only child of a `Regular` it makes **a submenu that is an image**; alongside other rows it's a picture with a caption and an action.

```go
menuet.Regular{
    Text: "Living room iMac",
    Children: func() []menuet.MenuItem {
        return []menuet.MenuItem{
            menuet.Image{Data: screenshotPNG, MaxWidth: 480},
            menuet.Separator{},
            menuet.Regular{Text: "Open full size", Clicked: openFull},
        }
    },
}
```

## How

`NSMenuItem.view` — the same mechanism the in-menu search field already uses. A custom view gets none of NSMenuItem's highlight/click behavior for free, so a clickable Image tracks the pointer itself, draws the selection background, and on mouseUp fires the item's action and dismisses the menu, reusing the existing `press:`/`representedObject` path.

## Design decisions

- **Source is `Data` ([]byte) or `Path`, exactly one.** There is deliberately **no URL field**: menuet would have to fetch it on the thread building the menu (hanging it) and couldn't carry an `Authorization` header. Fetch in Go — where your auth, caching and retries already are — and hand over bytes or a path. Neither/both logs rather than silently rendering blank.
- **Scale to fit** `MaxWidth`×`MaxHeight`, preserving aspect, never upscaling. Zero → a default 480×360 bound, so an unscaled screenshot can't push the menu off screen.
- **Cached**, keyed so it invalidates correctly: a digest of the bytes for `Data`, path + **mtime** for `Path` — so a screenshot rewritten to the same path shows the new picture, not a stale one.
- `Regular.Image` (the 16pt icon left of the text) is a *different thing* and unchanged; both docs cross-reference now.

## Snapshot gap closed

A new MenuItem type would have snapshotted to an **empty item** → blank rows on menuet.app. Snapshots now record an Image structurally (type, bound, data-vs-path) but **not the bytes** — a screenshot base64s to ~1MB, and a snapshot is a record of the menu, not an asset bundle. The html renderer draws a placeholder at the declared bound. Catalog's `menuet-demo.json` stays at 67KB.

## Catalog

New **Images** submenu: a submenu that is one picture, picture+caption+action, a clickable image, the `Path` source, and one 1440×900 source under three bounds. Pictures are generated in Go rather than shipped as assets — which is also the point.

## Test plan
- [x] `go build ./... && go vet ./... && go test ./...`
- [x] New `image_test.go`: serialization (base64 of `Data`, omitempty for `Path`), `Clickable` only when `Clicked` set, click routes to the callback, defaults stay in step with menuet.m
- [x] Catalog snapshotted end-to-end: all 7 image rows captured, both sources, 67KB
- [x] Catalog launches without crashing
- [ ] **Not machine-verifiable:** the actual AppKit rendering (highlight, click-to-dismiss, scaling) only runs when a menu is opened by hand — needs a human click-through