### PR TITLE
AutoUpdate: verified custom-feed source + fix Zip-Slip in unzipBundle

### DIFF
--- a/feedupdate_test.go
+++ b/feedupdate_test.go
@@ -1,0 +1,269 @@
+package menuet
+
+import (
+	"archive/zip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestVersionNewer(t *testing.T) {
+	cases := []struct {
+		current, offered string
+		want             bool
+	}{
+		{"0.1.7", "0.1.8", true},
+		{"0.1.7", "0.2.0", true},
+		{"0.1.7", "1.0.0", true},
+		{"0.1.7", "0.1.7", false}, // equal is not newer
+		{"0.1.7", "0.1.6", false}, // older
+		{"0.1.7", "0.1.70", true}, // numeric, not lexical (70 > 7)
+		{"v0.9", "v0.10", true},   // v-prefix stripped, 10 > 9
+		{"1.2", "1.2.1", true},    // extra component
+		{"1.2.1", "1.2", false},
+		{"0.1.7", "", false},        // unparseable offered -> fail closed
+		{"", "0.1.8", false},        // unparseable current -> fail closed
+		{"0.1.7", "garbage", false}, // fail closed
+		{"0.1.7", "1.x", false},     // partially numeric -> fail closed
+	}
+	for _, c := range cases {
+		if got := versionNewer(c.current, c.offered); got != c.want {
+			t.Errorf("versionNewer(%q, %q) = %v, want %v", c.current, c.offered, got, c.want)
+		}
+	}
+}
+
+func TestCheckFeedNewerOnly(t *testing.T) {
+	serve := func(cast appcast) *updateCandidate {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			json.NewEncoder(w).Encode(cast)
+		}))
+		defer srv.Close()
+		return checkFeed(srv.URL, "0.1.7")
+	}
+
+	if c := serve(appcast{Version: "0.1.8", URL: "https://x/a.zip", SHA256: "abc"}); c == nil {
+		t.Error("expected a candidate for a newer version")
+	} else if c.version != "0.1.8" || !c.fromFeed || c.sha256 != "abc" {
+		t.Errorf("candidate = %+v", c)
+	}
+	if c := serve(appcast{Version: "0.1.7", URL: "https://x/a.zip", SHA256: "abc"}); c != nil {
+		t.Error("must not offer the same version")
+	}
+	if c := serve(appcast{Version: "0.1.6", URL: "https://x/a.zip", SHA256: "abc"}); c != nil {
+		t.Error("must not offer an older version (no downgrade)")
+	}
+	// Missing sha256 -> fail closed even though the version is newer.
+	if c := serve(appcast{Version: "0.2.0", URL: "https://x/a.zip"}); c != nil {
+		t.Error("must refuse an appcast with no sha256")
+	}
+}
+
+func TestVerifySHA256(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f")
+	os.WriteFile(path, []byte("hello"), 0o600)
+	sum := sha256.Sum256([]byte("hello"))
+	good := hex.EncodeToString(sum[:])
+
+	if err := verifySHA256(path, good); err != nil {
+		t.Errorf("matching digest should verify: %v", err)
+	}
+	if err := verifySHA256(path, strings.ToUpper(good)); err != nil {
+		t.Errorf("digest compare must be case-insensitive: %v", err)
+	}
+	if err := verifySHA256(path, "deadbeef"); err == nil {
+		t.Error("mismatched digest must fail")
+	}
+}
+
+// zipEntry is a file to put in a test zip. link marks a symlink entry.
+type zipEntry struct {
+	name string
+	body string
+	link bool
+}
+
+func makeZip(t *testing.T, entries []zipEntry) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "update.zip")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	zw := zip.NewWriter(f)
+	for _, e := range entries {
+		hdr := &zip.FileHeader{Name: e.name}
+		switch {
+		case strings.HasSuffix(e.name, "/"):
+			hdr.SetMode(os.ModeDir | 0o755)
+		case e.link:
+			hdr.SetMode(os.ModeSymlink | 0o777)
+		default:
+			hdr.SetMode(0o644)
+		}
+		w, err := zw.CreateHeader(hdr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.HasSuffix(e.name, "/") {
+			w.Write([]byte(e.body))
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestUnzipBundleFindsTopLevelApp(t *testing.T) {
+	path := makeZip(t, []zipEntry{
+		{name: "My App.app/"},
+		{name: "My App.app/Contents/"},
+		{name: "My App.app/Contents/MacOS/"},
+		{name: "My App.app/Contents/MacOS/myapp", body: "binary"},
+	})
+	bundle, err := unzipBundle(path)
+	if err != nil {
+		t.Fatalf("unzipBundle: %v", err)
+	}
+	if filepath.Base(bundle) != "My App.app" {
+		t.Errorf("bundle = %q, want .../My App.app", bundle)
+	}
+}
+
+func TestUnzipBundleRejectsZipSlip(t *testing.T) {
+	// A classic Zip-Slip payload: escape the destination via ../.
+	path := makeZip(t, []zipEntry{
+		{name: "../../evil.txt", body: "pwned"},
+	})
+	if _, err := unzipBundle(path); err == nil {
+		t.Fatal("unzipBundle must reject a path-traversal entry")
+	} else if !strings.Contains(err.Error(), "escapes") {
+		t.Errorf("unexpected error: %v", err)
+	}
+	// And it must not have written the file outside the destination.
+	escaped := filepath.Join(filepath.Dir(filepath.Dir(path)), "evil.txt")
+	if _, err := os.Stat(escaped); err == nil {
+		t.Error("zip-slip file was written outside the destination")
+	}
+}
+
+func TestUnzipBundleRejectsSymlink(t *testing.T) {
+	path := makeZip(t, []zipEntry{
+		{name: "App.app/"},
+		{name: "App.app/Contents/MacOS/binary", body: "/etc/passwd", link: true},
+	})
+	if _, err := unzipBundle(path); err == nil {
+		t.Fatal("unzipBundle must reject a symlink entry")
+	} else if !strings.Contains(err.Error(), "symlink") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestPrepareUpdateVerifyChain drives download -> sha -> unzip -> version-bind
+// -> codesign with the codesign and version readers mocked, so the ordering
+// and fail-closed behavior are exercised without a real signed bundle.
+func TestPrepareUpdateVerifyChain(t *testing.T) {
+	zipPath := makeZip(t, []zipEntry{
+		{name: "App.app/"},
+		{name: "App.app/Contents/"},
+		{name: "App.app/Contents/MacOS/"},
+		{name: "App.app/Contents/MacOS/app", body: "v2 binary"},
+	})
+	zipBytes, err := os.ReadFile(zipPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(zipBytes)
+	goodSHA := hex.EncodeToString(sum[:])
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(zipBytes)
+	}))
+	defer srv.Close()
+
+	origVer, origSign := bundleVersionFn, verifyCodesignFn
+	defer func() { bundleVersionFn, verifyCodesignFn = origVer, origSign }()
+
+	candidate := func() *updateCandidate {
+		return &updateCandidate{version: "0.2.0", name: "App.zip", url: srv.URL, sha256: goodSHA, fromFeed: true}
+	}
+	app := func() *Application {
+		a := &Application{}
+		a.AutoUpdate.Version = "0.1.0"
+		a.AutoUpdate.VerifyTeamID = "TEAM123456"
+		return a
+	}
+
+	t.Run("happy path passes every gate", func(t *testing.T) {
+		bundleVersionFn = func(string) (string, error) { return "0.2.0", nil }
+		signCalled := false
+		verifyCodesignFn = func(path, team string) error {
+			signCalled = true
+			if team != "TEAM123456" {
+				t.Errorf("team = %q", team)
+			}
+			return nil
+		}
+		p, err := app().prepareUpdate(candidate(), t.TempDir())
+		if err != nil {
+			t.Fatalf("prepareUpdate: %v", err)
+		}
+		if filepath.Base(p) != "App.app" {
+			t.Errorf("path = %q", p)
+		}
+		if !signCalled {
+			t.Error("codesign verification was not run")
+		}
+	})
+
+	t.Run("sha mismatch aborts before unzip", func(t *testing.T) {
+		bundleVersionFn = func(string) (string, error) { return "0.2.0", nil }
+		verifyCodesignFn = func(string, string) error { t.Fatal("codesign should not run"); return nil }
+		c := candidate()
+		c.sha256 = "deadbeef"
+		if _, err := app().prepareUpdate(c, t.TempDir()); err == nil {
+			t.Fatal("expected sha mismatch error")
+		}
+	})
+
+	t.Run("stale bundle version aborts before codesign", func(t *testing.T) {
+		// Feed claims 0.2.0 but the actual bundle is old — the downgrade attack.
+		bundleVersionFn = func(string) (string, error) { return "0.0.9", nil }
+		verifyCodesignFn = func(string, string) error { t.Fatal("codesign should not run"); return nil }
+		if _, err := app().prepareUpdate(candidate(), t.TempDir()); err == nil {
+			t.Fatal("expected version-binding to reject a stale bundle")
+		}
+	})
+
+	t.Run("codesign failure aborts", func(t *testing.T) {
+		bundleVersionFn = func(string) (string, error) { return "0.2.0", nil }
+		verifyCodesignFn = func(string, string) error { return errFakeSign }
+		if _, err := app().prepareUpdate(candidate(), t.TempDir()); err == nil {
+			t.Fatal("expected codesign failure to abort")
+		}
+	})
+}
+
+type fakeSignError struct{}
+
+func (*fakeSignError) Error() string { return "fake codesign failure" }
+
+var errFakeSign = &fakeSignError{}
+
+func TestVerifyCodesignRejectsUnsigned(t *testing.T) {
+	// An unsigned directory must fail the real verifier — guards against a
+	// refactor loosening it to a bare --verify that would pass ad-hoc.
+	if err := verifyCodesignTeam(t.TempDir(), "AZGE7WP274"); err == nil {
+		t.Error("an unsigned directory must fail codesign verification")
+	}
+}

--- a/menuet.go
+++ b/menuet.go
@@ -30,15 +30,47 @@ type Application struct {
 	// Children returns the top level children
 	Children func() []MenuItem
 
-	// If Version and Repo are set, checks for updates every day
+	// AutoUpdate configures the daily self-updater. It updates from one of two
+	// sources: GitHub Releases (set Repo) or a custom JSON appcast (set
+	// FeedURL). Either way Version must be set — it identifies what's running
+	// and gates the "is there something newer?" check. A dev build with an
+	// empty Version never updates.
 	AutoUpdate struct {
 		Version string
-		Repo    string // For example "caseymrm/menuet"
+		Repo    string // GitHub "owner/name", e.g. "caseymrm/menuet"
 		// AllowPrerelease opts in to GitHub releases marked as prereleases.
 		// When false (the default), prereleases are filtered out before
 		// choosing what to update to. Apps on a prerelease are not
 		// downgraded to the latest stable — switch channels manually.
+		// (GitHub path only.)
 		AllowPrerelease bool
+
+		// FeedURL, when set, updates from a custom JSON appcast at this URL
+		// INSTEAD of GitHub. Required for a private repo, whose releases the
+		// unauthenticated GitHub API can't see. The appcast is:
+		//
+		//	{"version":"1.2.3",
+		//	 "url":"https://example.com/MyApp-1.2.3.zip",
+		//	 "sha256":"<hex of the zip>"}
+		//
+		// The updater downloads url, checks the zip's SHA-256 against sha256
+		// (fail closed), unzips it, confirms the bundle's own version is newer
+		// than what's running (so a manifest can't point a high version number
+		// at an old, still-signed build), and — because a self-hosted feed has
+		// none of GitHub's account-level trust — REQUIRES VerifyTeamID. When
+		// FeedURL is set without VerifyTeamID, RunApplication refuses to start
+		// the updater rather than run an unauthenticated one.
+		FeedURL string
+
+		// VerifyTeamID, when set, requires the downloaded .app to be validly
+		// codesigned by this Apple Developer Team (the OU of the Developer ID
+		// Application leaf) before it replaces the running app; a mismatch or
+		// an invalid signature aborts the update with no swap. This is the real
+		// authenticity gate — the auto-update path bypasses Gatekeeper, so the
+		// notarization ticket is never re-checked, and this pin takes its
+		// place. Applies to both the GitHub and FeedURL paths; required for
+		// FeedURL. Find your team ID at developer.apple.com → Membership.
+		VerifyTeamID string
 	}
 
 	// NotificationResponder is a handler called when notification respond
@@ -96,7 +128,15 @@ func (a *Application) RunApplication() {
 	if a.maybeWriteSnapshot() {
 		return
 	}
-	if a.AutoUpdate.Version != "" && a.AutoUpdate.Repo != "" {
+	if a.AutoUpdate.Version != "" && (a.AutoUpdate.Repo != "" || a.AutoUpdate.FeedURL != "") {
+		// A custom feed carries none of GitHub's account-level trust, so
+		// running it without an authenticity gate would be strictly worse than
+		// the GitHub path. Fail fast on the misconfiguration — a programmer
+		// error that must be caught before shipping, not silently degraded to
+		// an unverified updater.
+		if a.AutoUpdate.FeedURL != "" && a.AutoUpdate.VerifyTeamID == "" {
+			log.Fatalf("menuet: AutoUpdate.FeedURL requires AutoUpdate.VerifyTeamID")
+		}
 		go a.checkForUpdates()
 	}
 	C.createAndRunApplication()

--- a/update.go
+++ b/update.go
@@ -2,19 +2,41 @@ package menuet
 
 import (
 	"archive/zip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
 )
+
+// maxDownloadBytes caps an update download so a hostile or misbehaving origin
+// can't fill the disk before the integrity check runs. Comfortably larger than
+// any real menubar app bundle.
+const maxDownloadBytes = 500 << 20 // 512 MiB
+
+// downloadTimeout bounds a single update download.
+const downloadTimeout = 5 * time.Minute
+
+// updateCandidate is a source-agnostic description of an available update: the
+// two update sources (GitHub Releases, custom appcast) each resolve to one of
+// these, and the download/verify/install path is shared.
+type updateCandidate struct {
+	version  string // the offered version, for the prompt and the newer-check
+	name     string // download filename
+	url      string // zip download URL
+	sha256   string // expected hex SHA-256 of the zip; "" for the GitHub path
+	fromFeed bool   // true for the custom appcast path (enables version binding)
+}
 
 type release struct {
 	TagName    string `json:"tag_name"`
@@ -25,26 +47,54 @@ type release struct {
 	} `json:"assets"`
 }
 
+// appcast is the custom-feed manifest (AutoUpdate.FeedURL).
+type appcast struct {
+	Version string `json:"version"`
+	URL     string `json:"url"`
+	SHA256  string `json:"sha256"`
+}
+
 func (a *Application) checkForUpdates() {
 	checkForRestart()
 	ticker := time.NewTicker(24 * time.Hour)
 	for ; true; <-ticker.C {
-		release := checkForNewRelease(a.AutoUpdate.Repo, a.AutoUpdate.Version, a.AutoUpdate.AllowPrerelease)
-		if release == nil {
+		candidate := a.checkForUpdate()
+		if candidate == nil {
 			continue
 		}
 		button := a.Alert(Alert{
 			MessageText:     fmt.Sprintf("New version of %s available", a.Name),
-			InformativeText: fmt.Sprintf("Looks like %s of %s is now available- you're running %s", release.TagName, a.Name, a.AutoUpdate.Version),
+			InformativeText: fmt.Sprintf("Looks like %s of %s is now available- you're running %s", candidate.version, a.Name, a.AutoUpdate.Version),
 			Buttons:         []string{"Update now", "Remind me later"},
 		})
 		if button.Button == 0 {
-			err := updateApp(release)
-			if err != nil {
+			if err := a.installUpdate(candidate); err != nil {
 				log.Printf("Unable to update app: %v", err)
 			}
 		}
 	}
+}
+
+// checkForUpdate resolves the configured source to an available update, or nil
+// if none / on error. FeedURL wins when set.
+func (a *Application) checkForUpdate() *updateCandidate {
+	if a.AutoUpdate.Version == "" {
+		log.Printf("Not checking updates for dev version")
+		return nil
+	}
+	if a.AutoUpdate.FeedURL != "" {
+		return checkFeed(a.AutoUpdate.FeedURL, a.AutoUpdate.Version)
+	}
+	release := checkForNewRelease(a.AutoUpdate.Repo, a.AutoUpdate.Version, a.AutoUpdate.AllowPrerelease)
+	if release == nil {
+		return nil
+	}
+	name, url := downloadURL(release)
+	if url == "" {
+		log.Printf("No .zip asset on release %s", release.TagName)
+		return nil
+	}
+	return &updateCandidate{version: release.TagName, name: name, url: url}
 }
 
 func checkForRestart() {
@@ -63,11 +113,53 @@ func checkForRestart() {
 	syscall.Kill(ppid, syscall.SIGTERM)
 }
 
-func checkForNewRelease(githubProject, currentVersion string, allowPrerelease bool) *release {
-	if currentVersion == "" {
-		log.Printf("Not checking updates for dev version")
+// checkFeed fetches and parses the custom appcast, returning a candidate only
+// if it advertises a version strictly newer than currentVersion. It fails
+// closed: any fetch/parse error, a malformed or missing sha256, or a
+// not-newer version yields nil (no update).
+func checkFeed(feedURL, currentVersion string) *updateCandidate {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, feedURL, nil)
+	if err != nil {
+		log.Printf("Error building appcast request: %v", err)
 		return nil
 	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		log.Printf("Error fetching appcast: %v", err)
+		return nil
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		log.Printf("Appcast returned status %d", resp.StatusCode)
+		return nil
+	}
+	var cast appcast
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&cast); err != nil {
+		log.Printf("Error parsing appcast: %v", err)
+		return nil
+	}
+	if cast.URL == "" || cast.SHA256 == "" {
+		// A feed without a checksum is a feed with no integrity gate — refuse
+		// it rather than skip verification (unlike some daemons that treat a
+		// placeholder as "not ready yet", the menubar fails closed).
+		log.Printf("Appcast missing url or sha256; not updating")
+		return nil
+	}
+	if !versionNewer(currentVersion, cast.Version) {
+		return nil
+	}
+	return &updateCandidate{
+		version:  cast.Version,
+		name:     filepath.Base(cast.URL),
+		url:      cast.URL,
+		sha256:   cast.SHA256,
+		fromFeed: true,
+	}
+}
+
+func checkForNewRelease(githubProject, currentVersion string, allowPrerelease bool) *release {
 	releases, err := getReleasesFromGitHub(githubProject)
 	if err != nil {
 		log.Printf("Error fetching github releases: %v", err)
@@ -76,24 +168,68 @@ func checkForNewRelease(githubProject, currentVersion string, allowPrerelease bo
 	return getReleaseToUpdateTo(releases, currentVersion, allowPrerelease)
 }
 
-func updateApp(release *release) error {
-	name, url := downloadURL(release)
-	dir, err := ioutil.TempDir("", "menuetupdater")
+// installUpdate downloads, verifies, and swaps in a candidate. Every check
+// runs BEFORE the running app is touched: SHA-256 (feed only), then unzip,
+// then — for a feed — the bundle's own version must be newer than what's
+// running, then the codesign team pin (when VerifyTeamID is set). Only after
+// all of that does replaceExecutableAndRestart move anything.
+func (a *Application) installUpdate(c *updateCandidate) error {
+	dir, err := os.MkdirTemp("", "menuetupdater")
 	if err != nil {
-		return fmt.Errorf("Not updating, couldn't get tempdir: %v", err)
+		return fmt.Errorf("couldn't get tempdir: %v", err)
 	}
 	defer os.RemoveAll(dir)
-	log.Printf("Downloading archive...")
-	archivefile, err := downloadArchive(dir, name, url)
-	if err != nil {
-		return err
-	}
-	log.Printf("Unzipping bundle...")
-	newAppPath, err := unzipBundle(archivefile)
+
+	newAppPath, err := a.prepareUpdate(c, dir)
 	if err != nil {
 		return err
 	}
 	return replaceExecutableAndRestart(newAppPath)
+}
+
+// prepareUpdate performs everything up to (but not including) the swap: it
+// downloads into dir, runs all integrity and authenticity checks, and returns
+// the path to the verified .app. It is separated from installUpdate so the
+// full verify chain is testable without renaming/relaunching a real bundle.
+func (a *Application) prepareUpdate(c *updateCandidate, dir string) (string, error) {
+	log.Printf("Downloading archive...")
+	archivefile, err := downloadArchive(dir, c.name, c.url)
+	if err != nil {
+		return "", err
+	}
+	if c.sha256 != "" {
+		if err := verifySHA256(archivefile, c.sha256); err != nil {
+			return "", err
+		}
+	}
+	log.Printf("Unzipping bundle...")
+	newAppPath, err := unzipBundle(archivefile)
+	if err != nil {
+		return "", err
+	}
+	if newAppPath == "" {
+		return "", fmt.Errorf("update archive has no top-level .app bundle")
+	}
+	if c.fromFeed {
+		// The manifest's version claim decided whether to prompt, but the
+		// bundle's OWN version is the real gate: a compromised feed could
+		// advertise a high version while pointing at an old, still-validly-
+		// signed (and possibly vulnerable) build. Require the actual bundle to
+		// be newer than what's running.
+		bundleVersion, err := bundleVersionFn(newAppPath)
+		if err != nil {
+			return "", fmt.Errorf("couldn't read updated bundle version: %w", err)
+		}
+		if !versionNewer(a.AutoUpdate.Version, bundleVersion) {
+			return "", fmt.Errorf("refusing update: bundle version %q is not newer than %q", bundleVersion, a.AutoUpdate.Version)
+		}
+	}
+	if a.AutoUpdate.VerifyTeamID != "" {
+		if err := verifyCodesignFn(newAppPath, a.AutoUpdate.VerifyTeamID); err != nil {
+			return "", fmt.Errorf("update failed codesign verification: %w", err)
+		}
+	}
+	return newAppPath, nil
 }
 
 func replaceExecutableAndRestart(newAppPath string) error {
@@ -157,10 +293,17 @@ func bundlePathForExecutable(execPath string) string {
 
 func getReleasesFromGitHub(project string) ([]release, error) {
 	url := fmt.Sprintf("https://api.github.com/repos/%s/releases", project)
-	resp, err := http.Get(url)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
 	releases := make([]release, 0)
 	dec := json.NewDecoder(resp.Body)
 	err = dec.Decode(&releases)
@@ -193,18 +336,60 @@ func downloadArchive(tempdir, name, url string) (string, error) {
 		return "", fmt.Errorf("Not updating, couldn't create file in tempdir: %v", err)
 	}
 	defer out.Close()
-	resp, err := http.Get(url)
+	ctx, cancel := context.WithTimeout(context.Background(), downloadTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("Not updating, couldn't build request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("Not updating, couldn't open url: %v", err)
 	}
 	defer resp.Body.Close()
-	_, err = io.Copy(out, resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("Not updating, download returned status %d", resp.StatusCode)
+	}
+	// Cap the copy so a hostile origin can't fill the disk. LimitReader stops
+	// at the cap; a file exactly at the cap is indistinguishable from a
+	// truncated one, so treat hitting it as an error.
+	n, err := io.Copy(out, io.LimitReader(resp.Body, maxDownloadBytes+1))
 	if err != nil {
 		return "", fmt.Errorf("Not updating, couldn't copy data: %v", err)
+	}
+	if n > maxDownloadBytes {
+		return "", fmt.Errorf("Not updating, download exceeds %d bytes", maxDownloadBytes)
 	}
 	return filename, nil
 }
 
+// verifySHA256 fails closed unless the file's SHA-256 matches expected (hex).
+func verifySHA256(path, expected string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return err
+	}
+	got := hex.EncodeToString(h.Sum(nil))
+	if !strings.EqualFold(got, expected) {
+		return fmt.Errorf("sha256 mismatch: got %s, want %s", got, expected)
+	}
+	return nil
+}
+
+// unzipBundle extracts filename next to itself and returns the path to the
+// top-level .app bundle, or "" if there isn't one.
+//
+// It rejects two classes of malicious entry BEFORE anything is verified,
+// because extraction happens before the SHA/codesign checks and the archive
+// is attacker-controlled on the custom-feed path:
+//   - Zip-Slip: an entry whose path escapes the destination directory.
+//   - Symlinks: a symlink entry could let a later codesign-verified bundle
+//     resolve to different code at exec time, or point a write outside the tree.
 func unzipBundle(filename string) (string, error) {
 	destination := filepath.Dir(filename)
 	bundle := ""
@@ -214,12 +399,14 @@ func unzipBundle(filename string) (string, error) {
 	}
 	defer r.Close()
 	for _, f := range r.File {
-		rc, err := f.Open()
-		if err != nil {
-			return "", err
-		}
-		defer rc.Close()
 		fpath := filepath.Join(destination, f.Name)
+		// Containment check: the cleaned path must stay inside destination.
+		if fpath != destination && !strings.HasPrefix(fpath, destination+string(os.PathSeparator)) {
+			return "", fmt.Errorf("refusing update: archive entry %q escapes the destination", f.Name)
+		}
+		if f.Mode()&os.ModeSymlink != 0 {
+			return "", fmt.Errorf("refusing update: archive contains a symlink (%q)", f.Name)
+		}
 		if f.FileInfo().IsDir() {
 			if err = os.MkdirAll(fpath, os.ModePerm); err != nil {
 				return "", err
@@ -227,19 +414,26 @@ func unzipBundle(filename string) (string, error) {
 			if strings.HasSuffix(f.Name, ".app/") && !strings.Contains(filepath.Dir(f.Name), "/") {
 				bundle = fpath
 			}
-		} else {
-			if err = os.MkdirAll(filepath.Dir(fpath), os.ModePerm); err != nil {
-				return "", err
-			}
-			outFile, err := os.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
-			if err != nil {
-				return "", err
-			}
-			_, err = io.Copy(outFile, rc)
-			outFile.Close()
-			if err != nil {
-				return "", err
-			}
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return "", err
+		}
+		if err = os.MkdirAll(filepath.Dir(fpath), os.ModePerm); err != nil {
+			rc.Close()
+			return "", err
+		}
+		outFile, err := os.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+		if err != nil {
+			rc.Close()
+			return "", err
+		}
+		_, err = io.Copy(outFile, rc)
+		outFile.Close()
+		rc.Close()
+		if err != nil {
+			return "", err
 		}
 	}
 	return bundle, nil
@@ -275,4 +469,88 @@ func getReleaseToUpdateTo(releases []release, currentVersion string, allowPrerel
 		return nil
 	}
 	return &releases[0]
+}
+
+// versionNewer reports whether offered is strictly newer than current. Both are
+// compared as dotted numeric versions (a leading "v" is ignored). It fails
+// closed: if either can't be parsed as a dotted-numeric version, it returns
+// false (do not update) rather than guess.
+func versionNewer(current, offered string) bool {
+	c, ok := parseVersion(current)
+	if !ok {
+		return false
+	}
+	o, ok := parseVersion(offered)
+	if !ok {
+		return false
+	}
+	for i := 0; i < len(c) || i < len(o); i++ {
+		var cv, ov int
+		if i < len(c) {
+			cv = c[i]
+		}
+		if i < len(o) {
+			ov = o[i]
+		}
+		if ov != cv {
+			return ov > cv
+		}
+	}
+	return false // equal
+}
+
+// parseVersion splits a dotted-numeric version ("v1.2.3" -> [1 2 3]). ok is
+// false if it's empty or any component isn't a non-negative integer.
+func parseVersion(v string) ([]int, bool) {
+	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
+	if v == "" {
+		return nil, false
+	}
+	parts := strings.Split(v, ".")
+	out := make([]int, len(parts))
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil || n < 0 {
+			return nil, false
+		}
+		out[i] = n
+	}
+	return out, true
+}
+
+// bundleVersionFn reads a .app's CFBundleShortVersionString. It's a package
+// var so tests can supply a fake without a real bundle. verifyCodesignFn is
+// likewise injectable so the verify chain is testable without a signed app.
+var bundleVersionFn = bundleShortVersion
+var verifyCodesignFn = verifyCodesignTeam
+
+// bundleShortVersion reads CFBundleShortVersionString from the bundle's
+// Info.plist via plutil (always present on macOS).
+func bundleShortVersion(appPath string) (string, error) {
+	plist := filepath.Join(appPath, "Contents", "Info.plist")
+	out, err := exec.Command("/usr/bin/plutil", "-extract", "CFBundleShortVersionString", "raw", "-o", "-", plist).Output()
+	if err != nil {
+		return "", fmt.Errorf("plutil read CFBundleShortVersionString: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// verifyCodesignTeam requires appPath to be validly Developer-ID signed by
+// teamID. A bare `codesign --verify` passes on ANY signature (even ad-hoc), so
+// it only proves the bundle wasn't corrupted after signing — not that we signed
+// it. The designated requirement below pins Apple's anchor, the Developer ID
+// Application leaf, and the team OU, so a validly-signed bundle from a different
+// team is rejected. --deep verifies nested code in the bundle, not just the top
+// executable.
+func verifyCodesignTeam(appPath, teamID string) error {
+	requirement := fmt.Sprintf(
+		`=anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6]`+
+			` and certificate leaf[field.1.2.840.113635.100.6.1.13]`+
+			` and certificate leaf[subject.OU] = %q`, teamID)
+	out, err := exec.Command("/usr/bin/codesign", "--verify", "--deep", "--strict",
+		"-R", requirement, appPath).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("codesign verify (team %q): %w: %s", teamID, err, strings.TrimSpace(string(out)))
+	}
+	return nil
 }


### PR DESCRIPTION
Adds a verified custom-feed update source to menuet's auto-updater, and fixes a path-traversal hole in the existing unzip path. **Do not merge yet** — see the sequencing note at the bottom; wishy-watchy's PR depends on this being tagged.

## Why

wishy-watchy is a **private** repo, so the existing GitHub-Releases updater (unauthenticated `api.github.com`) can't see its releases. It also does no signature check — and critically, the auto-update path launches the new bundle via `exec`, which **bypasses Gatekeeper**, so the notarization ticket we staple is never re-checked on update. Today the only thing between a compromised release and code execution is TLS to the origin.

## What

**New `AutoUpdate` fields (additive — GitHub path is byte-for-byte unchanged when unset):**
- `FeedURL` — update from a JSON appcast `{version,url,sha256}` instead of GitHub.
- `VerifyTeamID` — require the downloaded `.app` to be validly Developer-ID codesigned by this team (the Developer ID Application leaf's OU) before it replaces the running app. This is the real authenticity gate, taking Gatekeeper's place. Required when `FeedURL` is set — `RunApplication` `log.Fatal`s on `FeedURL` without `VerifyTeamID` rather than run an unauthenticated updater (no `AllowUnverified` footgun).

**Zip-Slip fix in `unzipBundle` (both sources use it — this also hardens the existing GitHub path):**
- Reject any entry whose cleaned path escapes the destination. Extraction runs *before* the SHA/codesign checks, so on the feed path a `../../evil` entry was an arbitrary user-writable file write before any gate ran.
- Reject symlink entries (a symlinked `Contents/MacOS/binary` could let a codesign-verified bundle resolve to different code at exec).
- Fail loudly on an archive with no top-level `.app`.

**Feed verify chain, all before the running app is touched:** SHA-256 (fail closed; no placeholder-sentinel skip) → unzip → the bundle's own `CFBundleShortVersionString` must be newer than what's running (a manifest can't advertise a high version while pointing at an old, still-signed, vulnerable build) → `codesign --deep --strict` pinned to the team's designated requirement.

**Also:** dotted-numeric version compare that fails closed on unparseable input; `context` timeout + `io.LimitReader` cap on downloads (bare `http.Get` had neither); verify chain factored into `prepareUpdate` with injectable codesign/version readers so it's testable without a signed bundle.

## Tests
- `versionNewer` (numeric-not-lexical, v-prefix, fail-closed on garbage)
- appcast parse + newer-only + fail-closed on missing sha256
- SHA-256 verify (match, case-insensitive, mismatch)
- **Zip-Slip rejected** + asserts nothing written outside the destination
- **symlink entry rejected**
- full `prepareUpdate` chain (mocked codesign/version): happy path, SHA mismatch aborts pre-unzip, stale-bundle-version aborts pre-codesign (the downgrade attack), codesign failure aborts
- real `verifyCodesignTeam` rejects an unsigned directory

`go build ./... && go vet ./... && go test ./... && gofmt -l` all pass. (Pre-existing unrelated gofmt nit in `html/run.go`, left alone.)

## Threat-model notes (from an adversarial review of this branch)
- **Team-pin is the gate; SHA-256 is integrity, not authenticity** — the sha comes from the same origin as the url, so it defends against corruption/partial-swap, not a compromised feed. The team-pin is what stops a forged bundle.
- **Not covered, matching the wishy-watchy daemon's posture:** offline codesign checks no OCSP/ticket revocation, and there's no signature over the manifest itself (a compromised origin can still serve a *real* team-signed old build — which the bundle-version check rejects as a downgrade). EdDSA-over-the-manifest was considered and deferred.

## ⚠️ Release sequencing (this must be tagged before wishy-watchy can use it)
1. Merge this PR.
2. Tag `v2.14.0`, push the tag.
3. In wishy-watchy, `go get github.com/caseymrm/menuet/v2@v2.14.0` and drop the local `replace` (its PR flags this).